### PR TITLE
fix: Allow Cors in caddy issue #17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Notes:
 - Updated keycloak config to add ebo-client to ebo realm.
 
 ### Changed
+- Added cors support to caddy #17 (AP)
 
 ### Deprecated
 

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,6 +1,21 @@
 :80 {
 	encode gzip
 
+	# CORS headers for browser-based API access
+	header {
+		Access-Control-Allow-Origin "*"
+		Access-Control-Allow-Methods "GET, POST, PUT, DELETE, OPTIONS"
+		Access-Control-Allow-Headers "Content-Type, X-Debug-Subject, Authorization"
+	}
+
+	# Handle preflight OPTIONS requests
+	@options {
+		method OPTIONS
+	}
+	handle @options {
+		respond 204
+	}
+
 	# Proxy to the API container.
 	reverse_proxy api:8080 {
 		header_up X-Forwarded-Proto {scheme}

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,28 +1,27 @@
 :80 {
-	encode gzip
-
-	# CORS headers for browser-based API access
-	header {
-		Access-Control-Allow-Origin "*"
-		Access-Control-Allow-Methods "GET, POST, PUT, DELETE, OPTIONS"
-		Access-Control-Allow-Headers "Content-Type, X-Debug-Subject, Authorization"
-	}
-
-	# Handle preflight OPTIONS requests
-	@options {
-		method OPTIONS
-	}
-	handle @options {
-		respond 204
-	}
-
-	# Proxy to the API container.
-	reverse_proxy api:8080 {
-		header_up X-Forwarded-Proto {scheme}
-		header_up X-Forwarded-Host {host}
-		header_up X-Forwarded-For {remote_host}
-	}
-
-	# Optional proxy-level health endpoint
-	respond /proxy-healthz 200
+    encode gzip
+    # CORS headers for browser-based API access
+    header {
+        Access-Control-Allow-Origin "*"
+        # Added PATCH
+        Access-Control-Allow-Methods "GET, POST, PUT, PATCH, DELETE, OPTIONS"
+        # Added Idempotency-Key
+        Access-Control-Allow-Headers "Content-Type, X-Debug-Subject, Authorization, Idempotency-Key"
+    }
+    # Handle preflight OPTIONS requests
+    @options {
+        method OPTIONS
+    }
+    handle @options {
+        respond 204
+    }
+    # Proxy to the API container.
+    reverse_proxy api:8080 {
+        header_up X-Forwarded-Proto {scheme}
+        header_up X-Forwarded-Host {host}
+        header_up X-Forwarded-For {remote_host}
+    }
+    # Optional proxy-level health endpoint
+    respond /proxy-healthz 200
 }
+


### PR DESCRIPTION
# Title fix: add CORS headers to Caddy configuration for browser-based API access

## Commit Message
```
fix: add CORS headers to Caddy configuration for browser-based API access

Add CORS (Cross-Origin Resource Sharing) headers to the Caddy reverse
proxy configuration to allow browser-based applications to access the
API from different origins.

This change adds:
- Access-Control-Allow-Origin header set to "*" for all origins
- Access-Control-Allow-Methods for GET, POST, PUT, DELETE, OPTIONS
- Access-Control-Allow-Headers including Content-Type, X-Debug-Subject,
  and Authorization
- Proper handling of preflight OPTIONS requests with 204 responses

Fixes #17
```

## Description

### Problem
When attempting to access the API from a browser-based application (like an HTML page with JavaScript), requests are blocked by the browser's CORS policy. The error message indicates:

```
Access to fetch at 'http://localhost:8081/members' from origin 'http://127.0.0.1:8080' 
has been blocked by CORS policy: Response to preflight request doesn't pass access 
control check: No 'Access-Control-Allow-Origin' header is present on the requested resource.
```

This occurs because modern browsers enforce the Same-Origin Policy, which prevents web pages from making requests to a different domain/port than the one that served the page, unless the server explicitly allows it via CORS headers.

### Solution
The solution adds CORS support at the Caddy reverse proxy layer, which is the appropriate place to handle this since Caddy is already acting as the gateway to the API. This approach:

1. **Adds necessary CORS headers** to all responses:
   - `Access-Control-Allow-Origin: *` - Allows requests from any origin (suitable for development; can be restricted in production)
   - `Access-Control-Allow-Methods` - Specifies which HTTP methods are allowed
   - `Access-Control-Allow-Headers` - Specifies which custom headers (like `X-Debug-Subject`) are allowed

2. **Handles preflight requests** - Browsers send an OPTIONS request before certain cross-origin requests. The configuration now responds with a 204 (No Content) status for these preflight requests.

3. **Maintains existing functionality** - All existing proxy settings (gzip encoding, forwarded headers, health endpoint) remain unchanged.

### Changes Made
- Updated `deploy/Caddyfile` to include CORS headers and OPTIONS request handling

## Testing
After applying this change:
1. Restart the Caddy service: `docker compose restart caddy`
2. Access the API from a browser-based application on a different origin
3. Verify that requests succeed without CORS errors

## Related Issues
Fixes #17

---

## Updated Caddyfile

```caddy
:80 {
	encode gzip

	# CORS headers for browser-based API access
	header {
		Access-Control-Allow-Origin "*"
		Access-Control-Allow-Methods "GET, POST, PUT, DELETE, OPTIONS"
		Access-Control-Allow-Headers "Content-Type, X-Debug-Subject, Authorization"
	}

	# Handle preflight OPTIONS requests
	@options {
		method OPTIONS
	}
	handle @options {
		respond 204
	}

	# Proxy to the API container.
	reverse_proxy api:8080 {
		header_up X-Forwarded-Proto {scheme}
		header_up X-Forwarded-Host {host}
		header_up X-Forwarded-For {remote_host}
	}

	# Optional proxy-level health endpoint
	respond /proxy-healthz 200
}
```

## Notes
- The wildcard `*` for `Access-Control-Allow-Origin` is suitable for development environments
- For production, consider restricting this to specific trusted origins
- All existing proxy functionality remains intact