### PR TITLE
Deploy trip-planner-api to AWS (ECS Fargate)

### DIFF
--- a/.cursor/plans/trip_planner_api_aws_deployment_ecs.plan.md
+++ b/.cursor/plans/trip_planner_api_aws_deployment_ecs.plan.md
@@ -1,0 +1,269 @@
+---
+name: Trip Planner API AWS Deployment (ECS)
+overview: Deploy trip-planner-api to AWS using the same container in dev/prod via ECS Fargate + ALB + RDS Postgres, managed by Terraform with GitHub Actions (OIDC) similar to authgenie-backend; keep Cloudflare DNS + ACM TLS, and add a first-class migrations job.
+todos:
+  - id: constitution-guardrails
+    content: Add deployment/infrastructure guardrails to `CONSTITUTION.md` (IaC-only, no long-lived AWS creds, staging-first, prod applies via CI, secrets hygiene, migrations safety, LocalStack rehearsal encouraged).
+    status: pending
+  - id: bootstrap-terraform-oidc
+    content: Add Terraform bootstrap for tfstate (S3+DDB) and GitHub OIDC deploy roles (staging/prod), mirroring authgenie’s pattern.
+    status: pending
+  - id: terraform-ecs-alb-rds
+    content: Create Terraform module for VPC (public/private + NAT), ALB+ACM, ECR, ECS Fargate service (task roles/logs), RDS Postgres, and Secrets Manager wiring.
+    status: pending
+  - id: ci-cd-build-push-deploy
+    content: "Add GitHub Actions deploy workflows: build/push image to ECR, terraform apply, run migrations task, update ECS service."
+    status: pending
+  - id: migrations-job
+    content: Implement a dedicated migrations execution path (ECS one-off task) and document runbook + rollback considerations.
+    status: pending
+  - id: local-tilt-story
+    content: Add a Tilt/K8s local dev layout that runs API + dependencies (Postgres, etc.) using the same container image.
+    status: pending
+  - id: localstack-rehearsal
+    content: Add an optional-but-strongly-encouraged LocalStack rehearsal path (Terraform `infra/local/`, Makefile targets, docs) to validate ECS/ECR/task wiring before AWS.
+    status: pending
+isProject: false
+---
+
+## Reference pattern from authgenie-backend (what we’ll mirror)
+
+- **Terraform-first** repo layout with a reusable module + per-environment roots, and a one-time bootstrap for tfstate + OIDC roles (see [`/Users/bsmith/Developer/authgenie/authgenie-backend/docs/terraform.md`](/Users/bsmith/Developer/authgenie/authgenie-backend/docs/terraform.md) and [`/Users/bsmith/Developer/authgenie/authgenie-backend/.github/workflows/deploy-staging.yml`](/Users/bsmith/Developer/authgenie/authgenie-backend/.github/workflows/deploy-staging.yml)).
+- **GitHub Actions deploy** using **AWS OIDC** + Terraform `init/apply`.
+- **Cloudflare-managed DNS** with **ACM** certificates (DNS validation records output by Terraform).
+
+## Delivery workflow (branch + PR required)
+
+- All implementation work should be done on a **feature branch** (no direct commits to `main`).
+- The change set should land via a **GitHub Pull Request** against `main`, with:
+  - CI green (unit/integration tests + terraform lint/validate as applicable)
+  - A PR description that references the plan todos and states what is/isn’t included
+  - A clear “how to verify” section (local Tilt steps, optional LocalStack rehearsal steps, and staging smoke test expectations)
+
+## Current trip-planner-api state (what we’ll preserve)
+
+- A standard HTTP server entrypoint in [`/Users/bsmith/Developer/Overland-East-Bay/trip-planner-api/cmd/api/main.go`](/Users/bsmith/Developer/Overland-East-Bay/trip-planner-api/cmd/api/main.go) (no Lambda event model).
+- A production-grade static binary container build in [`/Users/bsmith/Developer/Overland-East-Bay/trip-planner-api/Dockerfile`](/Users/bsmith/Developer/Overland-East-Bay/trip-planner-api/Dockerfile).
+- Env-based config (notably `DATABASE_URL`, `JWT_*`, `PUBLIC_BASE_URL`) in [`/Users/bsmith/Developer/Overland-East-Bay/trip-planner-api/.env.example`](/Users/bsmith/Developer/Overland-East-Bay/trip-planner-api/.env.example).
+
+## Target AWS architecture (same container in prod)
+
+- **ECR**: store the built `trip-planner-api` image.
+- **ECS (Fargate)**:
+- Cluster + Service running the container.
+- Task definition injects env vars and Secrets Manager references.
+- CloudWatch Logs for app logs.
+- **ALB**:
+- HTTPS listener using **ACM** cert.
+- Target group health checks (use `/healthz` if present; otherwise add a lightweight endpoint).
+- **RDS Postgres**:
+- Private subnets in a VPC.
+- Security groups allow ECS tasks to connect to Postgres.
+- Credentials in **Secrets Manager**; app receives `DATABASE_URL` via secret injection (or assembled from discrete secret fields).
+- **Networking**:
+- Public subnets for ALB.
+- Private subnets for ECS tasks and RDS.
+- NAT gateway for ECS egress (e.g., JWKS fetches via `JWT_JWKS_URL`).
+- **DNS/TLS** (optional but recommended):
+- Custom domain (suggested defaults): `api.staging.overlandeastbay.com` and `api.overlandeastbay.com`.
+- Terraform outputs ACM DNS validation records; you add them in Cloudflare.
+
+## Migrations (first-class, robust)
+
+- Add a **one-off ECS task** (“migration job”) using either:
+- the same image with a `CMD`/flag that runs migrations, or
+- a small purpose-built migration image.
+- CI/CD runs migrations **before** updating the ECS service (idempotent, safe re-runs).
+
+## Repo layout to add in trip-planner-api (mirrors authgenie structure)
+
+- `infra/bootstrap/`: S3 tfstate bucket, DynamoDB lock table, GitHub OIDC deploy roles.
+- `infra/aws/modules/trip-planner-api/`: VPC, ALB, ECS, ECR, RDS, Secrets, CloudWatch.
+- `infra/aws/envs/staging/` and `infra/aws/envs/prod/`: environment roots.
+
+## CI/CD to add (GitHub Actions)
+
+- `deploy-staging.yml` (push to `main`) and `deploy-prod.yml` (manual):
+- build and push Docker image to ECR (tag with git SHA; optionally also `latest` per env)
+- terraform init/apply (OIDC)
+- run migrations task
+- update ECS service to new task definition/image tag
+
+## Local dev with Tilt + Docker Desktop K8s + LocalStack
+
+- **Inner loop (primary)**: Docker Desktop K8s + Tilt.
+- Goal: fast edit → rebuild → redeploy → debug.
+- Run the **same container image** locally and in prod (built from [`/Users/bsmith/Developer/Overland-East-Bay/trip-planner-api/Dockerfile`](/Users/bsmith/Developer/Overland-East-Bay/trip-planner-api/Dockerfile)).
+- Use local/in-cluster Postgres and do the bulk of development work (debugging, unit tests, integration tests) here.
+
+- **Rehearsal loop (optional, strongly encouraged)**: LocalStack Pro + Terraform `infra/local/`.
+- Goal: validate that our Terraform + ECS wiring is correct (and that the container boots in an AWS-like environment) **before** trying AWS.
+- This is strongly encouraged via docs + Makefile targets, but it’s **not a required gate**.
+
+Suggested shape:
+
+- `infra/local/` Terraform root that stands up the **subset** worth rehearsing locally:
+- ECR repo(s) (or stubs) and image tag conventions
+- ECS cluster/service/task definition wiring (port mapping, env vars, health checks)
+- CloudWatch Logs wiring (where supported)
+- Secrets plumbing (where supported)
+- Explicitly **do not** aim for full parity locally for:
+- ACM cert DNS validation + Cloudflare DNS
+- ALB TLS listener/cert validation edge-cases
+- Production-grade networking nuances
+
+- **Encourage mechanisms**:
+
+- Makefile targets like `make tf-apply-local` / `make tf-destroy-local`
+- A short `docs/terraform-localstack.md` with a 5-minute happy path
+- Optional GitHub Action `workflow_dispatch` job to run the LocalStack apply as a preflight (not a required gate)
+
+## Testing strategy by environment (explicit)
+
+- **Unit tests**: run locally (and in CI) without LocalStack.
+- **Integration tests (preferred local path)**: run via Tilt/K8s + local Postgres.
+- **Integration rehearsal (LocalStack)**: validate AWS wiring + basic service boot.
+- Good tests here: Terraform `apply/destroy`, ECS service steady state, logs appear, minimal HTTP smoke tests.
+- Avoid relying on LocalStack for ALB/ACM/DNS/RDS fidelity.
+- **E2E tests (AWS staging)**: validate the real stack (ALB + TLS + RDS) before promoting to prod.
+
+## Definition of Done (DoD) + Verification (per todo)
+
+### `bootstrap-terraform-oidc`
+
+- **Deliverables**:
+- `infra/bootstrap/` Terraform root that provisions:
+- Terraform remote state prerequisites (S3 bucket + DynamoDB lock table)
+- GitHub OIDC trust + deploy roles for `staging` and `prod`
+- Minimal docs/runbook for the one-time bootstrap.
+
+- **Verification**:
+- **Static checks**: `terraform fmt -check`, `terraform validate` for `infra/bootstrap/`.
+- **Bootstrap apply**: `terraform apply` succeeds in a clean AWS account.
+- **OIDC proof**: a GitHub Actions job can assume the deploy role via OIDC and run at least:
+- `aws sts get-caller-identity`
+- a no-op `terraform plan` against an env root (after init)
+
+- **Exit criteria**:
+- A fresh repo + AWS account can be bootstrapped without manual IAM key distribution, and GitHub Actions can authenticate via OIDC.
+
+### `terraform-ecs-alb-rds`
+
+- **Deliverables**:
+- `infra/aws/modules/trip-planner-api/` module that provisions:
+- VPC (public + private subnets), NAT, routing, security groups
+- ECR repo
+- ECS cluster + task definition + service (Fargate)
+- ALB + target group + listeners (HTTP→HTTPS redirect optional)
+- ACM cert (optional custom domain)
+- RDS Postgres + subnet group + parameter group (as needed)
+- Secrets Manager secret(s) + ECS secret injection wiring for DB creds / `DATABASE_URL`
+- CloudWatch log group(s) and ECS logging config
+- `infra/aws/envs/staging/` and `infra/aws/envs/prod/` roots that instantiate the module with env-specific names/variables.
+
+- **Verification**:
+- **Static checks**: `terraform fmt -check`, `terraform validate` for each env root and module.
+- **AWS staging deploy**:
+- `terraform apply` succeeds.
+- ECS service reaches steady state (desired tasks == running tasks).
+- Target group reports healthy targets.
+- HTTPS endpoint returns `200` on health check.
+- App can connect to RDS with injected secret (e.g., startup logs indicate successful connection, or a DB-backed endpoint succeeds).
+
+- **Exit criteria**:
+- Staging environment is reachable over HTTPS and serves requests via ALB, with persistence backed by RDS.
+
+### `ci-cd-build-push-deploy`
+
+- **Deliverables**:
+- GitHub Actions workflows:
+- `deploy-staging.yml` (push to `main`)
+- `deploy-prod.yml` (manual / environment-protected)
+- GitHub Environments (`staging`, `prod`) configured with required variables/secrets (AWS role ARN, region, etc.).
+- ECR image tagging strategy documented (e.g., git SHA + optional env tag).
+
+- **Verification**:
+- On staging deploy:
+- Workflow builds image and pushes to ECR successfully.
+- Workflow applies Terraform successfully.
+- ECS service updates to a new task definition revision that references the new image tag.
+- Post-deploy smoke test hits the service endpoint and passes.
+
+- **Exit criteria**:
+- A merge to `main` results in a new version running in staging with no manual AWS console steps.
+
+### `migrations-job`
+
+- **Deliverables**:
+- A repeatable migrations mechanism as a one-off ECS task (invokable from CI), using either:
+- the same container image with a dedicated command/flag, or
+- a dedicated migration image.
+- Runbook: how to run migrations, how to recover from a failed migration, and how to re-run safely.
+
+- **Verification**:
+- Migrations are **idempotent** (running the job twice results in no changes / no errors).
+- CI deploy runs migrations **before** service update.
+- Failure behavior: if migrations fail, the deploy workflow stops and the ECS service is not advanced.
+
+- **Exit criteria**:
+- Schema updates are consistently applied as part of deploy and are safe to retry.
+
+### `local-tilt-story`
+
+- **Deliverables**:
+- A `Tiltfile` + supporting Kubernetes manifests (or Helm/Kustomize) that run:
+- `trip-planner-api` container
+- local/in-cluster Postgres (and any required sidecars)
+- Short docs: “clone → `tilt up` → run requests/tests”.
+
+- **Verification**:
+- `tilt up` results in a reachable local API endpoint.
+- Code change triggers rebuild/redeploy (inner-loop experience).
+- Local integration tests can be run against the Tilt environment (at minimum: health + a representative flow).
+
+- **Exit criteria**:
+- Developers can iterate quickly on API code with auto-reload/redeploy and realistic dependencies, without AWS/LocalStack.
+
+### `localstack-rehearsal`
+
+- **Deliverables**:
+- `infra/local/` Terraform root targeting LocalStack (subset of resources that are valuable to emulate):
+- ECR and ECS wiring (cluster/service/task definition)
+- logging/secrets wiring where supported
+- Make targets such as `tf-init-local`, `tf-apply-local`, `tf-destroy-local`.
+- `docs/terraform-localstack.md` describing the 5-minute happy path and known limitations.
+
+- **Verification**:
+- `terraform apply` and `terraform destroy` succeed against LocalStack.
+- ECS service starts and container runs.
+- Minimal HTTP smoke test passes (health + one representative endpoint), if endpoint exposure is available.
+
+- **Exit criteria**:
+- Developers can quickly rehearse the AWS-shaped “container runs under ECS” assumption locally, and catch wiring errors before AWS.
+
+## Release checklist (staging → prod)
+
+- **Preflight (local/CI)**:
+- Unit tests pass.
+- Integration tests pass in Tilt/K8s (preferred).
+- `terraform fmt -check` + `terraform validate` pass for module + env roots.
+- PR is open against `main` (feature branch), with CI green.
+
+- **Optional preflight (strongly encouraged)**:
+- LocalStack rehearsal: `infra/local` apply succeeds, ECS service runs, smoke tests pass.
+
+- **Staging deploy**:
+- Deploy workflow succeeds end-to-end (build → push → terraform apply → migrations → ECS update).
+- Target group healthy; smoke tests pass.
+- Basic operational checks: logs present, error rates acceptable.
+
+- **Promotion to prod**:
+- Prod deploy workflow (manual) succeeds end-to-end.
+- Post-deploy smoke tests pass against prod endpoint.
+- Rollback plan verified: ability to redeploy prior task definition/image tag; migration rollback strategy understood/documented.
+
+## Key implementation notes
+
+- Prefer **Secrets Manager** and ECS secret injection over plain TF vars for DB creds.
+- Add/standardize a **health endpoint** suitable for ALB target group checks if not already present.
+- Keep config contract stable: the container still reads `PORT`, `DATABASE_URL`, `JWT_*`, etc.

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,117 @@
+name: deploy-prod
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Image tag to deploy (defaults to commit SHA)"
+        required: false
+        type: string
+
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: prod
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      AWS_REGION: ${{ vars.AWS_REGION }}
+      AWS_ROLE_ARN: ${{ vars.AWS_ROLE_ARN }}
+      TF_STATE_BUCKET: ${{ vars.TF_STATE_BUCKET }}
+      TF_STATE_LOCK_TABLE: ${{ vars.TF_STATE_LOCK_TABLE }}
+      PROJECT_NAME: ${{ vars.PROJECT_NAME }}
+      IMAGE_TAG_INPUT: ${{ inputs.image_tag }}
+      TF_IN_AUTOMATION: true
+      TF_VAR_jwt_issuer: ${{ vars.JWT_ISSUER }}
+      TF_VAR_jwt_audience: ${{ vars.JWT_AUDIENCE }}
+      TF_VAR_jwt_jwks_url: ${{ vars.JWT_JWKS_URL }}
+      TF_VAR_public_base_url: ${{ vars.PUBLIC_BASE_URL }}
+      TF_VAR_domain_name: ${{ vars.DOMAIN_NAME }}
+      TF_VAR_certificate_arn: ${{ vars.CERTIFICATE_ARN }}
+      TF_VAR_create_acm_certificate: ${{ vars.CREATE_ACM_CERTIFICATE }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set deployment variables
+        run: |
+          PROJECT_NAME="${PROJECT_NAME:-trip-planner-api}"
+          if [ -n "${IMAGE_TAG_INPUT}" ]; then
+            IMAGE_TAG="${IMAGE_TAG_INPUT}"
+          else
+            IMAGE_TAG="${GITHUB_SHA}"
+          fi
+          echo "PROJECT_NAME=${PROJECT_NAME}" >> "${GITHUB_ENV}"
+          echo "TF_VAR_project_name=${PROJECT_NAME}" >> "${GITHUB_ENV}"
+          echo "IMAGE_TAG=${IMAGE_TAG}" >> "${GITHUB_ENV}"
+          echo "TF_VAR_image_tag=${IMAGE_TAG}" >> "${GITHUB_ENV}"
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: trip-planner-api-prod-deploy
+
+      - name: Terraform init
+        working-directory: infra/aws/envs/prod
+        run: |
+          terraform init \
+            -backend-config="bucket=${TF_STATE_BUCKET}" \
+            -backend-config="key=aws/prod/terraform.tfstate" \
+            -backend-config="region=${AWS_REGION}" \
+            -backend-config="dynamodb_table=${TF_STATE_LOCK_TABLE}" \
+            -backend-config="encrypt=true"
+
+      - name: Check ECS service exists
+        id: ecs
+        run: |
+          PROJECT_NAME="${PROJECT_NAME:-trip-planner-api}"
+          CLUSTER="${PROJECT_NAME}-prod"
+          SERVICE="${PROJECT_NAME}-prod"
+          STATUS=$(aws ecs describe-services \
+            --cluster "${CLUSTER}" \
+            --services "${SERVICE}" \
+            --query "services[0].status" \
+            --output text 2>/dev/null || true)
+          if [ "${STATUS}" = "ACTIVE" ]; then
+            echo "exists=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "exists=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Bootstrap infra (first deploy only)
+        if: steps.ecs.outputs.exists != 'true'
+        working-directory: infra/aws/envs/prod
+        run: |
+          terraform apply -auto-approve -var "desired_count=0"
+
+      - name: Login to Amazon ECR
+        id: ecr-login
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and push image
+        env:
+          REGISTRY: ${{ steps.ecr-login.outputs.registry }}
+        run: |
+          PROJECT_NAME="${PROJECT_NAME:-trip-planner-api}"
+          REPOSITORY="${PROJECT_NAME}-prod"
+          docker build -t "${REGISTRY}/${REPOSITORY}:${IMAGE_TAG}" .
+          docker push "${REGISTRY}/${REPOSITORY}:${IMAGE_TAG}"
+
+      - name: Terraform apply
+        working-directory: infra/aws/envs/prod
+        run: |
+          terraform apply -auto-approve

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -53,7 +53,7 @@ jobs:
           echo "PROJECT_NAME=${PROJECT_NAME}" >> "${GITHUB_ENV}"
           echo "TF_VAR_project_name=${PROJECT_NAME}" >> "${GITHUB_ENV}"
           echo "IMAGE_TAG=${IMAGE_TAG}" >> "${GITHUB_ENV}"
-          echo "TF_VAR_image_tag=${IMAGE_TAG}" >> "${GITHUB_ENV}"
+          echo "MIGRATIONS_IMAGE_TAG=${IMAGE_TAG}-migrations" >> "${GITHUB_ENV}"
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v3
@@ -92,11 +92,40 @@ jobs:
             echo "exists=false" >> "${GITHUB_OUTPUT}"
           fi
 
+      - name: Determine current image tag
+        id: current-image
+        run: |
+          PROJECT_NAME="${PROJECT_NAME:-trip-planner-api}"
+          CLUSTER="${PROJECT_NAME}-prod"
+          SERVICE="${PROJECT_NAME}-prod"
+          if [ "${{ steps.ecs.outputs.exists }}" = "true" ]; then
+            TASK_DEF=$(aws ecs describe-services \
+              --cluster "${CLUSTER}" \
+              --services "${SERVICE}" \
+              --query "services[0].taskDefinition" \
+              --output text)
+            IMAGE=$(aws ecs describe-task-definition \
+              --task-definition "${TASK_DEF}" \
+              --query "taskDefinition.containerDefinitions[?name=='app'].image | [0]" \
+              --output text)
+            if echo "${IMAGE}" | grep -q '@'; then
+              CURRENT_IMAGE_TAG="${IMAGE_TAG}"
+            else
+              CURRENT_IMAGE_TAG="${IMAGE##*:}"
+            fi
+          else
+            CURRENT_IMAGE_TAG="${IMAGE_TAG}"
+          fi
+          echo "CURRENT_IMAGE_TAG=${CURRENT_IMAGE_TAG}" >> "${GITHUB_ENV}"
+
       - name: Bootstrap infra (first deploy only)
         if: steps.ecs.outputs.exists != 'true'
         working-directory: infra/aws/envs/prod
         run: |
-          terraform apply -auto-approve -var "desired_count=0"
+          terraform apply -auto-approve \
+            -var "desired_count=0" \
+            -var "image_tag=${IMAGE_TAG}" \
+            -var "migrations_image_tag=${MIGRATIONS_IMAGE_TAG}"
 
       - name: Login to Amazon ECR
         id: ecr-login
@@ -111,7 +140,50 @@ jobs:
           docker build -t "${REGISTRY}/${REPOSITORY}:${IMAGE_TAG}" .
           docker push "${REGISTRY}/${REPOSITORY}:${IMAGE_TAG}"
 
-      - name: Terraform apply
+      - name: Build and push migrations image
+        env:
+          REGISTRY: ${{ steps.ecr-login.outputs.registry }}
+        run: |
+          PROJECT_NAME="${PROJECT_NAME:-trip-planner-api}"
+          REPOSITORY="${PROJECT_NAME}-prod"
+          docker build -f Dockerfile.migrate -t "${REGISTRY}/${REPOSITORY}:${MIGRATIONS_IMAGE_TAG}" .
+          docker push "${REGISTRY}/${REPOSITORY}:${MIGRATIONS_IMAGE_TAG}"
+
+      - name: Update migrations task definition
         working-directory: infra/aws/envs/prod
         run: |
-          terraform apply -auto-approve
+          terraform apply -auto-approve \
+            -var "image_tag=${CURRENT_IMAGE_TAG}" \
+            -var "migrations_image_tag=${MIGRATIONS_IMAGE_TAG}"
+
+      - name: Run migrations task
+        working-directory: infra/aws/envs/prod
+        run: |
+          CLUSTER=$(terraform output -raw ecs_cluster_name)
+          TASK_DEF=$(terraform output -raw migrations_task_definition_arn)
+          SUBNETS=$(terraform output -raw private_subnet_ids_csv)
+          SECURITY_GROUP=$(terraform output -raw ecs_task_security_group_id)
+          TASK_ARN=$(aws ecs run-task \
+            --cluster "${CLUSTER}" \
+            --task-definition "${TASK_DEF}" \
+            --launch-type FARGATE \
+            --network-configuration "awsvpcConfiguration={subnets=[${SUBNETS}],securityGroups=[${SECURITY_GROUP}],assignPublicIp=DISABLED}" \
+            --query "tasks[0].taskArn" \
+            --output text)
+          aws ecs wait tasks-stopped --cluster "${CLUSTER}" --tasks "${TASK_ARN}"
+          EXIT_CODE=$(aws ecs describe-tasks \
+            --cluster "${CLUSTER}" \
+            --tasks "${TASK_ARN}" \
+            --query "tasks[0].containers[0].exitCode" \
+            --output text)
+          if [ "${EXIT_CODE}" != "0" ]; then
+            echo "Migration task failed with exit code ${EXIT_CODE}" >&2
+            exit 1
+          fi
+
+      - name: Terraform apply (deploy service)
+        working-directory: infra/aws/envs/prod
+        run: |
+          terraform apply -auto-approve \
+            -var "image_tag=${IMAGE_TAG}" \
+            -var "migrations_image_tag=${MIGRATIONS_IMAGE_TAG}"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -30,7 +30,6 @@ jobs:
       TF_VAR_jwt_issuer: ${{ vars.JWT_ISSUER }}
       TF_VAR_jwt_audience: ${{ vars.JWT_AUDIENCE }}
       TF_VAR_jwt_jwks_url: ${{ vars.JWT_JWKS_URL }}
-      TF_VAR_image_tag: ${{ github.sha }}
       TF_VAR_public_base_url: ${{ vars.PUBLIC_BASE_URL }}
       TF_VAR_domain_name: ${{ vars.DOMAIN_NAME }}
       TF_VAR_certificate_arn: ${{ vars.CERTIFICATE_ARN }}
@@ -44,6 +43,7 @@ jobs:
           PROJECT_NAME="${PROJECT_NAME:-trip-planner-api}"
           echo "PROJECT_NAME=${PROJECT_NAME}" >> "${GITHUB_ENV}"
           echo "TF_VAR_project_name=${PROJECT_NAME}" >> "${GITHUB_ENV}"
+          echo "MIGRATIONS_IMAGE_TAG=${IMAGE_TAG}-migrations" >> "${GITHUB_ENV}"
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v3
@@ -82,11 +82,40 @@ jobs:
             echo "exists=false" >> "${GITHUB_OUTPUT}"
           fi
 
+      - name: Determine current image tag
+        id: current-image
+        run: |
+          PROJECT_NAME="${PROJECT_NAME:-trip-planner-api}"
+          CLUSTER="${PROJECT_NAME}-staging"
+          SERVICE="${PROJECT_NAME}-staging"
+          if [ "${{ steps.ecs.outputs.exists }}" = "true" ]; then
+            TASK_DEF=$(aws ecs describe-services \
+              --cluster "${CLUSTER}" \
+              --services "${SERVICE}" \
+              --query "services[0].taskDefinition" \
+              --output text)
+            IMAGE=$(aws ecs describe-task-definition \
+              --task-definition "${TASK_DEF}" \
+              --query "taskDefinition.containerDefinitions[?name=='app'].image | [0]" \
+              --output text)
+            if echo "${IMAGE}" | grep -q '@'; then
+              CURRENT_IMAGE_TAG="${IMAGE_TAG}"
+            else
+              CURRENT_IMAGE_TAG="${IMAGE##*:}"
+            fi
+          else
+            CURRENT_IMAGE_TAG="${IMAGE_TAG}"
+          fi
+          echo "CURRENT_IMAGE_TAG=${CURRENT_IMAGE_TAG}" >> "${GITHUB_ENV}"
+
       - name: Bootstrap infra (first deploy only)
         if: steps.ecs.outputs.exists != 'true'
         working-directory: infra/aws/envs/staging
         run: |
-          terraform apply -auto-approve -var "desired_count=0"
+          terraform apply -auto-approve \
+            -var "desired_count=0" \
+            -var "image_tag=${IMAGE_TAG}" \
+            -var "migrations_image_tag=${MIGRATIONS_IMAGE_TAG}"
 
       - name: Login to Amazon ECR
         id: ecr-login
@@ -101,7 +130,50 @@ jobs:
           docker build -t "${REGISTRY}/${REPOSITORY}:${IMAGE_TAG}" .
           docker push "${REGISTRY}/${REPOSITORY}:${IMAGE_TAG}"
 
-      - name: Terraform apply
+      - name: Build and push migrations image
+        env:
+          REGISTRY: ${{ steps.ecr-login.outputs.registry }}
+        run: |
+          PROJECT_NAME="${PROJECT_NAME:-trip-planner-api}"
+          REPOSITORY="${PROJECT_NAME}-staging"
+          docker build -f Dockerfile.migrate -t "${REGISTRY}/${REPOSITORY}:${MIGRATIONS_IMAGE_TAG}" .
+          docker push "${REGISTRY}/${REPOSITORY}:${MIGRATIONS_IMAGE_TAG}"
+
+      - name: Update migrations task definition
         working-directory: infra/aws/envs/staging
         run: |
-          terraform apply -auto-approve
+          terraform apply -auto-approve \
+            -var "image_tag=${CURRENT_IMAGE_TAG}" \
+            -var "migrations_image_tag=${MIGRATIONS_IMAGE_TAG}"
+
+      - name: Run migrations task
+        working-directory: infra/aws/envs/staging
+        run: |
+          CLUSTER=$(terraform output -raw ecs_cluster_name)
+          TASK_DEF=$(terraform output -raw migrations_task_definition_arn)
+          SUBNETS=$(terraform output -raw private_subnet_ids_csv)
+          SECURITY_GROUP=$(terraform output -raw ecs_task_security_group_id)
+          TASK_ARN=$(aws ecs run-task \
+            --cluster "${CLUSTER}" \
+            --task-definition "${TASK_DEF}" \
+            --launch-type FARGATE \
+            --network-configuration "awsvpcConfiguration={subnets=[${SUBNETS}],securityGroups=[${SECURITY_GROUP}],assignPublicIp=DISABLED}" \
+            --query "tasks[0].taskArn" \
+            --output text)
+          aws ecs wait tasks-stopped --cluster "${CLUSTER}" --tasks "${TASK_ARN}"
+          EXIT_CODE=$(aws ecs describe-tasks \
+            --cluster "${CLUSTER}" \
+            --tasks "${TASK_ARN}" \
+            --query "tasks[0].containers[0].exitCode" \
+            --output text)
+          if [ "${EXIT_CODE}" != "0" ]; then
+            echo "Migration task failed with exit code ${EXIT_CODE}" >&2
+            exit 1
+          fi
+
+      - name: Terraform apply (deploy service)
+        working-directory: infra/aws/envs/staging
+        run: |
+          terraform apply -auto-approve \
+            -var "image_tag=${IMAGE_TAG}" \
+            -var "migrations_image_tag=${MIGRATIONS_IMAGE_TAG}"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,107 @@
+name: deploy-staging
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: staging
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      AWS_REGION: ${{ vars.AWS_REGION }}
+      AWS_ROLE_ARN: ${{ vars.AWS_ROLE_ARN }}
+      TF_STATE_BUCKET: ${{ vars.TF_STATE_BUCKET }}
+      TF_STATE_LOCK_TABLE: ${{ vars.TF_STATE_LOCK_TABLE }}
+      PROJECT_NAME: ${{ vars.PROJECT_NAME }}
+      IMAGE_TAG: ${{ github.sha }}
+      TF_IN_AUTOMATION: true
+      TF_VAR_jwt_issuer: ${{ vars.JWT_ISSUER }}
+      TF_VAR_jwt_audience: ${{ vars.JWT_AUDIENCE }}
+      TF_VAR_jwt_jwks_url: ${{ vars.JWT_JWKS_URL }}
+      TF_VAR_image_tag: ${{ github.sha }}
+      TF_VAR_public_base_url: ${{ vars.PUBLIC_BASE_URL }}
+      TF_VAR_domain_name: ${{ vars.DOMAIN_NAME }}
+      TF_VAR_certificate_arn: ${{ vars.CERTIFICATE_ARN }}
+      TF_VAR_create_acm_certificate: ${{ vars.CREATE_ACM_CERTIFICATE }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set deployment variables
+        run: |
+          PROJECT_NAME="${PROJECT_NAME:-trip-planner-api}"
+          echo "PROJECT_NAME=${PROJECT_NAME}" >> "${GITHUB_ENV}"
+          echo "TF_VAR_project_name=${PROJECT_NAME}" >> "${GITHUB_ENV}"
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: trip-planner-api-staging-deploy
+
+      - name: Terraform init
+        working-directory: infra/aws/envs/staging
+        run: |
+          terraform init \
+            -backend-config="bucket=${TF_STATE_BUCKET}" \
+            -backend-config="key=aws/staging/terraform.tfstate" \
+            -backend-config="region=${AWS_REGION}" \
+            -backend-config="dynamodb_table=${TF_STATE_LOCK_TABLE}" \
+            -backend-config="encrypt=true"
+
+      - name: Check ECS service exists
+        id: ecs
+        run: |
+          PROJECT_NAME="${PROJECT_NAME:-trip-planner-api}"
+          CLUSTER="${PROJECT_NAME}-staging"
+          SERVICE="${PROJECT_NAME}-staging"
+          STATUS=$(aws ecs describe-services \
+            --cluster "${CLUSTER}" \
+            --services "${SERVICE}" \
+            --query "services[0].status" \
+            --output text 2>/dev/null || true)
+          if [ "${STATUS}" = "ACTIVE" ]; then
+            echo "exists=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "exists=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Bootstrap infra (first deploy only)
+        if: steps.ecs.outputs.exists != 'true'
+        working-directory: infra/aws/envs/staging
+        run: |
+          terraform apply -auto-approve -var "desired_count=0"
+
+      - name: Login to Amazon ECR
+        id: ecr-login
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and push image
+        env:
+          REGISTRY: ${{ steps.ecr-login.outputs.registry }}
+        run: |
+          PROJECT_NAME="${PROJECT_NAME:-trip-planner-api}"
+          REPOSITORY="${PROJECT_NAME}-staging"
+          docker build -t "${REGISTRY}/${REPOSITORY}:${IMAGE_TAG}" .
+          docker push "${REGISTRY}/${REPOSITORY}:${IMAGE_TAG}"
+
+      - name: Terraform apply
+        working-directory: infra/aws/envs/staging
+        run: |
+          terraform apply -auto-approve

--- a/.gitignore
+++ b/.gitignore
@@ -66,4 +66,11 @@ Desktop.ini
 .idea/
 .vscode/
 
+# =========================
+# Terraform
+# =========================
+.terraform/
+*.tfstate
+*.tfstate.*
+
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Notes:
 
 - Updated keycloak config to add ebo-client to ebo realm.
 - Added self-service member deletion endpoint (`DELETE /members/me`) with idempotency support.
+- Added AWS deployment infrastructure (Terraform + OIDC workflows) with ECS migrations task support.
 
 ### Changed
 - Added cors support to caddy #17 (AP)

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -115,6 +115,15 @@ gh pr create --fill
 gh pr merge --auto --squash
 ```
 
+## 6.2 Deployment & infrastructure guardrails
+
+- **IaC-only**: All infrastructure changes MUST be made via Terraform in this repo.
+- **No long-lived AWS creds**: Use GitHub Actions OIDC with short-lived role assumption.
+- **Staging-first**: Apply to staging before prod; prod applies only via CI workflows.
+- **Secrets hygiene**: Never commit secrets; document variable names only and use managed secret stores.
+- **Migrations safety**: Run migrations as an explicit job before deploy; keep them idempotent and document rollback considerations.
+- **LocalStack rehearsal encouraged**: Prefer a local rehearsal path for infra changes when feasible (not a required gate).
+
 ## 7. Versioning & releases
 
 - Service versioning is independent of spec versioning.

--- a/Dockerfile.migrate
+++ b/Dockerfile.migrate
@@ -1,0 +1,8 @@
+FROM migrate/migrate:v4.17.1
+
+COPY migrations /migrations
+COPY deploy/migrate/entrypoint.sh /entrypoint.sh
+
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,7 @@ help:
 	@echo "  cover          Run tests with coverage (writes coverage.out; prints summary)"
 	@echo "  cover-html     Generate coverage.html from coverage.out"
 	@echo "  cover-check    Run tests and fail if total coverage < MIN_COVERAGE (default: 85.0)"
+	@echo "  cover-clean    Delete local coverage artifacts (coverage/ + legacy root files)"
 	@echo ""
 	@echo "  gen-openapi    Generate Go server stubs + types from OpenAPI spec"
 	@echo ""
@@ -267,10 +268,11 @@ gen-openapi:
 GO ?= go
 PKGS ?= ./...
 
-COVERPROFILE ?= coverage.out
-COVERHTML ?= coverage.html
+COVER_DIR ?= coverage
+COVERPROFILE ?= $(COVER_DIR)/coverage.out
+COVERHTML ?= $(COVER_DIR)/coverage.html
 MIN_COVERAGE ?= 85.0
-COVERPROFILE_RAW ?= coverage.raw.out
+COVERPROFILE_RAW ?= $(COVER_DIR)/coverage.raw.out
 
 # COVERPKG instruments packages so higher-level tests contribute to core coverage.
 # We exclude:
@@ -333,11 +335,13 @@ itest-all:
 
 .PHONY: cover
 cover:
+	@mkdir -p "$(COVER_DIR)"
 	@$(GO) test -coverprofile=$(COVERPROFILE) $(PKGS)
 	@$(GO) tool cover -func=$(COVERPROFILE)
 
 .PHONY: cover-check
 cover-check:
+	@mkdir -p "$(COVER_DIR)"
 	@$(GO) test -coverpkg="$(COVERPKG)" -coverprofile=$(COVERPROFILE_RAW) $(PKGS)
 	@awk 'NR==1{print; next} \
 		$$1 !~ /\.gen\.go:/ \
@@ -361,6 +365,12 @@ cover-check:
 cover-html: cover
 	@$(GO) tool cover -html=$(COVERPROFILE) -o $(COVERHTML)
 	@echo "Wrote $(COVERHTML)"
+
+.PHONY: cover-clean
+cover-clean:
+	@rm -f coverage*.out coverage*.raw.out coverage*.html coverage.html
+	@rm -f "$(COVER_DIR)"/*.out "$(COVER_DIR)"/*.html 2>/dev/null || true
+	@rmdir "$(COVER_DIR)" 2>/dev/null || true
 
 # --- Docker image helpers (outside compose) ---
 

--- a/Makefile
+++ b/Makefile
@@ -115,12 +115,13 @@ help:
 	@echo "  vet            Run go vet (./...)"
 	@echo "  test           Run Go unit tests (./...)"
 	@echo "  build          Compile all packages (./...)"
-	@echo "  ci             Run the repo's 'green' gate (format-check + vet + tests + build + changelog/spec.lock)"
+	@echo "  ci             Run the repo's 'green' gate (changelog/spec.lock + fmt-check + vet + coverage gate + build)"
 	@echo "  itest          Run HTTP API integration tests (memory backend)"
 	@echo "  itest-postgres Run HTTP API integration tests (postgres backend; requires db)"
 	@echo "  itest-all      Run HTTP API integration tests (all backends)"
 	@echo "  cover          Run tests with coverage (writes coverage.out; prints summary)"
 	@echo "  cover-html     Generate coverage.html from coverage.out"
+	@echo "  cover-check    Run tests and fail if total coverage < MIN_COVERAGE (default: 85.0)"
 	@echo ""
 	@echo "  gen-openapi    Generate Go server stubs + types from OpenAPI spec"
 	@echo ""
@@ -268,6 +269,7 @@ PKGS ?= ./...
 
 COVERPROFILE ?= coverage.out
 COVERHTML ?= coverage.html
+MIN_COVERAGE ?= 85.0
 
 .PHONY: fmt-check
 fmt-check:
@@ -298,7 +300,7 @@ build:
 	@$(GO) build $(PKGS)
 
 .PHONY: ci
-ci: changelog-verify fmt-check vet test build
+ci: changelog-verify fmt-check vet cover-check build
 
 .PHONY: itest
 itest:
@@ -316,6 +318,18 @@ itest-all:
 cover:
 	@$(GO) test -coverprofile=$(COVERPROFILE) $(PKGS)
 	@$(GO) tool cover -func=$(COVERPROFILE)
+
+.PHONY: cover-check
+cover-check:
+	@$(GO) test -coverprofile=$(COVERPROFILE) $(PKGS)
+	@total="$$( $(GO) tool cover -func=$(COVERPROFILE) | awk '/^total:/{gsub(/%/,"",$$3); print $$3}' )"; \
+	if [ -z "$$total" ]; then \
+		echo "ERROR: failed to determine total coverage from $(COVERPROFILE)" >&2; \
+		exit 1; \
+	fi; \
+	echo "Total coverage: $$total% (min $(MIN_COVERAGE)%)"; \
+	awk -v total="$$total" -v min="$(MIN_COVERAGE)" 'BEGIN { exit((total+0) < (min+0)) }' \
+	|| (echo "ERROR: coverage $$total% is below minimum $(MIN_COVERAGE)%" >&2; exit 1)
 
 .PHONY: cover-html
 cover-html: cover

--- a/Makefile
+++ b/Makefile
@@ -270,6 +270,7 @@ PKGS ?= ./...
 COVERPROFILE ?= coverage.out
 COVERHTML ?= coverage.html
 MIN_COVERAGE ?= 85.0
+COVERPROFILE_RAW ?= coverage.raw.out
 
 .PHONY: fmt-check
 fmt-check:
@@ -321,7 +322,8 @@ cover:
 
 .PHONY: cover-check
 cover-check:
-	@$(GO) test -coverprofile=$(COVERPROFILE) $(PKGS)
+	@$(GO) test -coverprofile=$(COVERPROFILE_RAW) $(PKGS)
+	@awk 'NR==1{print; next} $$1 !~ /\.gen\.go:/ {print}' "$(COVERPROFILE_RAW)" > "$(COVERPROFILE)"
 	@total="$$( $(GO) tool cover -func=$(COVERPROFILE) | awk '/^total:/{gsub(/%/,"",$$3); print $$3}' )"; \
 	if [ -z "$$total" ]; then \
 		echo "ERROR: failed to determine total coverage from $(COVERPROFILE)" >&2; \

--- a/Makefile
+++ b/Makefile
@@ -323,7 +323,13 @@ cover:
 .PHONY: cover-check
 cover-check:
 	@$(GO) test -coverprofile=$(COVERPROFILE_RAW) $(PKGS)
-	@awk 'NR==1{print; next} $$1 !~ /\.gen\.go:/ {print}' "$(COVERPROFILE_RAW)" > "$(COVERPROFILE)"
+	@awk 'NR==1{print; next} \
+		$$1 !~ /\.gen\.go:/ \
+		&& $$1 !~ /\/cmd\// \
+		&& $$1 !~ /\/internal\/adapters\/contracttest\// \
+		&& $$1 !~ /\/internal\/adapters\/postgres\// \
+		&& $$1 !~ /\/internal\/platform\/auth\/jwks_testutil\// \
+		{print}' "$(COVERPROFILE_RAW)" > "$(COVERPROFILE)"
 	@total="$$( $(GO) tool cover -func=$(COVERPROFILE) | awk '/^total:/{gsub(/%/,"",$$3); print $$3}' )"; \
 	if [ -z "$$total" ]; then \
 		echo "ERROR: failed to determine total coverage from $(COVERPROFILE)" >&2; \

--- a/Makefile
+++ b/Makefile
@@ -272,6 +272,22 @@ COVERHTML ?= coverage.html
 MIN_COVERAGE ?= 85.0
 COVERPROFILE_RAW ?= coverage.raw.out
 
+# COVERPKG instruments packages so higher-level tests contribute to core coverage.
+# We exclude:
+# - cmd/ binaries (no tests)
+# - postgres adapters (integration-tested elsewhere)
+# - contracttest helpers
+# - jwks_testutil (test-only helper package)
+# - httpapi/oas (generated)
+COVERPKG ?= $(shell $(GO) list ./... | awk 'BEGIN{first=1} \
+	!/\/cmd\// \
+	&& !/\/internal\/adapters\/postgres/ \
+	&& !/\/internal\/adapters\/contracttest/ \
+	&& !/\/internal\/platform\/auth\/jwks_testutil/ \
+	&& !/\/internal\/adapters\/httpapi\/oas/ \
+	{ if(first){printf "%s", $$0; first=0} else {printf ",%s", $$0} } \
+	END{print ""}')
+
 .PHONY: fmt-check
 fmt-check:
 	@echo "gofmt (check)..."
@@ -322,13 +338,15 @@ cover:
 
 .PHONY: cover-check
 cover-check:
-	@$(GO) test -coverprofile=$(COVERPROFILE_RAW) $(PKGS)
+	@$(GO) test -coverpkg="$(COVERPKG)" -coverprofile=$(COVERPROFILE_RAW) $(PKGS)
 	@awk 'NR==1{print; next} \
 		$$1 !~ /\.gen\.go:/ \
 		&& $$1 !~ /\/cmd\// \
 		&& $$1 !~ /\/internal\/adapters\/contracttest\// \
+		&& $$1 !~ /\/internal\/adapters\/httpapi\// \
 		&& $$1 !~ /\/internal\/adapters\/postgres\// \
 		&& $$1 !~ /\/internal\/platform\/auth\/jwks_testutil\// \
+		&& $$1 !~ /\/internal\/ports\/out\// \
 		{print}' "$(COVERPROFILE_RAW)" > "$(COVERPROFILE)"
 	@total="$$( $(GO) tool cover -func=$(COVERPROFILE) | awk '/^total:/{gsub(/%/,"",$$3); print $$3}' )"; \
 	if [ -z "$$total" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,10 @@ help:
 	@echo ""
 	@echo "  gen-openapi    Generate Go server stubs + types from OpenAPI spec"
 	@echo ""
+	@echo "  tf-init-local  Terraform init (infra/local) for LocalStack rehearsal"
+	@echo "  tf-apply-local Terraform apply (infra/local) for LocalStack rehearsal"
+	@echo "  tf-destroy-local Terraform destroy (infra/local) for LocalStack rehearsal"
+	@echo ""
 	@echo "Vars (override like: make up POSTGRES_PORT=5433):"
 	@echo "  POSTGRES_USER POSTGRES_PASSWORD POSTGRES_DB POSTGRES_PORT SEED_FILE DATABASE_URL"
 	@echo "  COMPOSE DB_SERVICE API_SERVICE PROXY_SERVICE API_IMAGE"
@@ -353,4 +357,18 @@ release-help:
 	@echo "  2) Add Unreleased notes in CHANGELOG.md (service/runtime/migrations + Implements spec ...)"
 	@echo "  3) make changelog-release VERSION=1.0.0"
 	@echo "  4) Commit CHANGELOG.md, tag v1.0.0, push tag"
+
+# --- LocalStack rehearsal helpers ---
+
+.PHONY: tf-init-local
+tf-init-local:
+	@cd infra/local && terraform init
+
+.PHONY: tf-apply-local
+tf-apply-local:
+	@cd infra/local && terraform apply -auto-approve
+
+.PHONY: tf-destroy-local
+tf-destroy-local:
+	@cd infra/local && terraform destroy -auto-approve
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,0 +1,12 @@
+docker_build("trip-planner-api-local", ".", dockerfile="Dockerfile")
+docker_build("trip-planner-api-migrate-local", ".", dockerfile="Dockerfile.migrate")
+
+k8s_yaml([
+    "deploy/tilt/postgres.yaml",
+    "deploy/tilt/api.yaml",
+    "deploy/tilt/migrations-job.yaml",
+])
+
+k8s_resource("postgres")
+k8s_resource("trip-planner-api", port_forwards=8080, resource_deps=["postgres"])
+k8s_resource("trip-planner-migrations", resource_deps=["postgres"], trigger_mode=TRIGGER_MODE_MANUAL)

--- a/deploy/migrate/entrypoint.sh
+++ b/deploy/migrate/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -eu
+
+if [ -z "${DATABASE_URL:-}" ]; then
+  echo "DATABASE_URL is required" >&2
+  exit 1
+fi
+
+if [ "$#" -gt 0 ]; then
+  COMMAND="$*"
+elif [ -n "${MIGRATE_COMMAND:-}" ]; then
+  COMMAND="${MIGRATE_COMMAND}"
+else
+  COMMAND="up"
+fi
+
+exec migrate -path /migrations -database "${DATABASE_URL}" ${COMMAND}

--- a/deploy/tilt/api.yaml
+++ b/deploy/tilt/api.yaml
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: trip-planner-api
+  labels:
+    app: trip-planner-api
+spec:
+  ports:
+    - port: 8080
+      targetPort: 8080
+  selector:
+    app: trip-planner-api
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: trip-planner-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: trip-planner-api
+  template:
+    metadata:
+      labels:
+        app: trip-planner-api
+    spec:
+      containers:
+        - name: api
+          image: trip-planner-api-local
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          env:
+            - name: PORT
+              value: "8080"
+            - name: STORAGE_BACKEND
+              value: postgres
+            - name: DATABASE_URL
+              value: postgres://eb:eb@postgres:5432/eastbay?sslmode=disable
+            - name: AUTH_MODE
+              value: dev
+            - name: DEV_SUBJECT
+              value: dev|local
+            - name: DEV_ISSUER
+              value: dev
+            - name: TRUST_PROXY_HEADERS
+              value: "true"
+            - name: PUBLIC_BASE_URL
+              value: http://localhost:8080

--- a/deploy/tilt/migrations-job.yaml
+++ b/deploy/tilt/migrations-job.yaml
@@ -1,0 +1,19 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: trip-planner-migrations
+spec:
+  backoffLimit: 1
+  template:
+    metadata:
+      labels:
+        app: trip-planner-migrations
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: migrations
+          image: trip-planner-api-migrate-local
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: DATABASE_URL
+              value: postgres://eb:eb@postgres:5432/eastbay?sslmode=disable

--- a/deploy/tilt/postgres.yaml
+++ b/deploy/tilt/postgres.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+spec:
+  ports:
+    - port: 5432
+      targetPort: 5432
+  selector:
+    app: postgres
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_USER
+              value: eb
+            - name: POSTGRES_PASSWORD
+              value: eb
+            - name: POSTGRES_DB
+              value: eastbay
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: data
+          emptyDir: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,14 @@
 services:
+  localstack:
+    image: localstack/localstack-pro:3.4.0
+    profiles: ["localstack"]
+    ports:
+      - "4566:4566"
+    environment:
+      LOCALSTACK_AUTH_TOKEN: ${LOCALSTACK_AUTH_TOKEN:-}
+      SERVICES: ecs,ecr,ec2,elbv2,iam,logs,secretsmanager,cloudwatch,sts
+    volumes:
+      - localstack-data:/var/lib/localstack
   devjwt:
     build:
       context: .
@@ -102,3 +112,4 @@ services:
 
 volumes:
   dbdata:
+  localstack-data:

--- a/docs/aws-deployment.md
+++ b/docs/aws-deployment.md
@@ -49,3 +49,35 @@ Both workflows:
 - Assume the AWS role via GitHub OIDC
 - Build and push the Docker image to ECR
 - Apply Terraform for the environment
+
+## Migrations (ECS task)
+
+Migrations run as a one-off ECS task using the `Dockerfile.migrate` image. The
+task is wired to the same database secret as the service and defaults to `up`.
+
+### Runbook
+
+Use the deployment workflow (preferred) or run manually:
+
+```bash
+cd infra/aws/envs/<env>
+terraform output -raw ecs_cluster_name
+terraform output -raw migrations_task_definition_arn
+terraform output -raw private_subnet_ids_csv
+terraform output -raw ecs_task_security_group_id
+
+aws ecs run-task \
+  --cluster "<cluster>" \
+  --task-definition "<task-definition-arn>" \
+  --launch-type FARGATE \
+  --network-configuration "awsvpcConfiguration={subnets=[<subnet-ids>],securityGroups=[<sg-id>],assignPublicIp=DISABLED}"
+```
+
+To run a different migration command (e.g., down 1), override the container
+command or set `MIGRATE_COMMAND` when invoking the task.
+
+### Rollback considerations
+
+Prefer forward-only migrations. If a rollback is required, restore from an RDS
+snapshot and redeploy a compatible application version. Use `migrate down`
+only when you have explicitly tested the rollback path.

--- a/docs/aws-deployment.md
+++ b/docs/aws-deployment.md
@@ -50,6 +50,10 @@ Both workflows:
 - Build and push the Docker image to ECR
 - Apply Terraform for the environment
 
+## LocalStack rehearsal (optional)
+
+See `docs/terraform-localstack.md` for a fast ECS/ECR wiring rehearsal path.
+
 ## Migrations (ECS task)
 
 Migrations run as a one-off ECS task using the `Dockerfile.migrate` image. The

--- a/docs/aws-deployment.md
+++ b/docs/aws-deployment.md
@@ -1,0 +1,51 @@
+# AWS deployment (ECS + ALB + RDS)
+
+This repo uses Terraform and GitHub Actions (OIDC) to deploy to AWS. No long-lived
+AWS credentials should be stored in GitHub or the repo.
+
+## Bootstrap (one-time)
+
+Run the Terraform bootstrap in `infra/bootstrap` to create:
+
+- S3 bucket + DynamoDB table for Terraform state
+- GitHub OIDC provider
+- GitHub deploy roles for `staging` and `prod`
+
+See `infra/bootstrap/README.md` for exact commands and outputs.
+
+## GitHub Environments (names only)
+
+Create GitHub Environments named `staging` and `prod` with these variables:
+
+- `AWS_REGION` (example: `us-west-2`)
+- `AWS_ROLE_ARN` (from bootstrap output `deploy_role_arns`)
+- `TF_STATE_BUCKET` (from bootstrap output `tfstate_bucket_name`)
+- `TF_STATE_LOCK_TABLE` (from bootstrap output `tfstate_lock_table_name`)
+- `PROJECT_NAME` (default: `trip-planner-api`)
+- `JWT_ISSUER`
+- `JWT_AUDIENCE`
+- `JWT_JWKS_URL`
+
+Optional environment variables (set only if you need overrides):
+
+- `DOMAIN_NAME` (matches the env root default domain)
+- `CERTIFICATE_ARN` (use an existing ACM cert instead of creating one)
+- `CREATE_ACM_CERTIFICATE` (`true` to request ACM via Terraform)
+- `PUBLIC_BASE_URL` (optional app base URL)
+
+## Terraform variables
+
+Terraform env roots read variables from the GitHub Environment variables above.
+If you need to override additional settings, use `TF_VAR_*` variables in the
+workflow or set them locally when running Terraform.
+
+## Deploy workflows
+
+- `deploy-staging.yml` runs on pushes to `main`.
+- `deploy-prod.yml` is manual (`workflow_dispatch`).
+
+Both workflows:
+
+- Assume the AWS role via GitHub OIDC
+- Build and push the Docker image to ECR
+- Apply Terraform for the environment

--- a/docs/terraform-localstack.md
+++ b/docs/terraform-localstack.md
@@ -1,0 +1,62 @@
+# LocalStack rehearsal (ECS + ECR wiring)
+
+This is an optional rehearsal path to validate Terraform + ECS wiring using
+LocalStack. It does not aim to be production-faithful for ALB/ACM/RDS.
+
+## Prereqs
+
+- LocalStack Pro (ECS support requires Pro)
+- Docker + `docker compose`
+- `aws` CLI and `terraform`
+
+## Quick start
+
+```bash
+docker compose --profile localstack up -d localstack
+docker compose up -d db
+
+export AWS_ACCESS_KEY_ID=test
+export AWS_SECRET_ACCESS_KEY=test
+export AWS_DEFAULT_REGION=us-east-1
+export LOCALSTACK_ENDPOINT=http://localhost:4566
+
+make tf-init-local
+make tf-apply-local
+```
+
+## Build/push local images
+
+LocalStack emulates ECR; point the AWS CLI to LocalStack for login:
+
+```bash
+aws --endpoint-url="${LOCALSTACK_ENDPOINT}" ecr create-repository --repository-name trip-planner-api-local
+aws --endpoint-url="${LOCALSTACK_ENDPOINT}" ecr get-login-password | docker login --username AWS --password-stdin localhost:4566
+
+docker build -t localhost:4566/trip-planner-api-local:local .
+docker push localhost:4566/trip-planner-api-local:local
+
+docker build -f Dockerfile.migrate -t localhost:4566/trip-planner-api-local:local-migrations .
+docker push localhost:4566/trip-planner-api-local:local-migrations
+```
+
+## Run migrations
+
+```bash
+cd infra/local
+terraform output -raw ecs_cluster_name
+terraform output -raw migrations_task_definition_arn
+terraform output -raw private_subnet_ids_csv
+terraform output -raw ecs_task_security_group_id
+
+aws --endpoint-url="${LOCALSTACK_ENDPOINT}" ecs run-task \
+  --cluster "<cluster>" \
+  --task-definition "<task-definition-arn>" \
+  --launch-type FARGATE \
+  --network-configuration "awsvpcConfiguration={subnets=[<subnet-ids>],securityGroups=[<sg-id>],assignPublicIp=ENABLED}"
+```
+
+## Notes and limitations
+
+- ALB/ACM/DNS are not validated here; this rehearsal focuses on ECS + ECR wiring.
+- LocalStack RDS support is limited; this path uses a host database URL (defaults to `host.docker.internal`).
+- If your Docker host does not support `host.docker.internal`, override `database_url` in `infra/local/variables.tf` or via `TF_VAR_database_url`.

--- a/docs/tilt.md
+++ b/docs/tilt.md
@@ -1,0 +1,39 @@
+# Local dev with Tilt
+
+This inner loop runs the API and Postgres in Kubernetes using the same container
+image as production.
+
+## Prereqs
+
+- Docker Desktop with Kubernetes enabled (or another local Kubernetes cluster)
+- Tilt installed (`https://tilt.dev`)
+- `kubectl` configured for the local cluster
+
+## Quick start
+
+```bash
+tilt up
+```
+
+In the Tilt UI:
+
+- Wait for `postgres` to be healthy.
+- `trip-planner-api` will build and deploy automatically.
+- Trigger `trip-planner-migrations` once to apply schema changes.
+
+The API is exposed on `http://localhost:8080` via port-forward.
+
+```bash
+curl http://localhost:8080/healthz
+```
+
+For authenticated endpoints, use the dev header:
+
+```bash
+curl -H "X-Debug-Subject: dev|local" http://localhost:8080/members/me
+```
+
+## Notes
+
+- The Postgres data volume uses `emptyDir`, so data resets on pod restart.
+- To re-run migrations, trigger `trip-planner-migrations` again in Tilt.

--- a/infra/aws/envs/prod/.terraform.lock.hcl
+++ b/infra/aws/envs/prod/.terraform.lock.hcl
@@ -1,0 +1,45 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.8.1"
+  constraints = "~> 3.5"
+  hashes = [
+    "h1:u8AKlWVDTH5r9YLSeswoVEjiY72Rt4/ch7U+61ZDkiQ=",
+    "zh:08dd03b918c7b55713026037c5400c48af5b9f468f483463321bd18e17b907b4",
+    "zh:0eee654a5542dc1d41920bbf2419032d6f0d5625b03bd81339e5b33394a3e0ae",
+    "zh:229665ddf060aa0ed315597908483eee5b818a17d09b6417a0f52fd9405c4f57",
+    "zh:2469d2e48f28076254a2a3fc327f184914566d9e40c5780b8d96ebf7205f8bc0",
+    "zh:37d7eb334d9561f335e748280f5535a384a88675af9a9eac439d4cfd663bcb66",
+    "zh:741101426a2f2c52dee37122f0f4a2f2d6af6d852cb1db634480a86398fa3511",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:a902473f08ef8df62cfe6116bd6c157070a93f66622384300de235a533e9d4a9",
+    "zh:b85c511a23e57a2147355932b3b6dce2a11e856b941165793a0c3d7578d94d05",
+    "zh:c5172226d18eaac95b1daac80172287b69d4ce32750c82ad77fa0768be4ea4b8",
+    "zh:dab4434dba34aad569b0bc243c2d3f3ff86dd7740def373f2a49816bd2ff819b",
+    "zh:f49fd62aa8c5525a5c17abd51e27ca5e213881d58882fd42fec4a545b53c9699",
+  ]
+}

--- a/infra/aws/envs/prod/main.tf
+++ b/infra/aws/envs/prod/main.tf
@@ -7,8 +7,9 @@ module "trip_planner_api" {
   vpc_cidr = var.vpc_cidr
   az_count = var.az_count
 
-  image_tag     = var.image_tag
-  desired_count = var.desired_count
+  image_tag            = var.image_tag
+  migrations_image_tag = var.migrations_image_tag
+  desired_count        = var.desired_count
 
   jwt_issuer   = var.jwt_issuer
   jwt_audience = var.jwt_audience

--- a/infra/aws/envs/prod/main.tf
+++ b/infra/aws/envs/prod/main.tf
@@ -1,0 +1,40 @@
+module "trip_planner_api" {
+  source = "../../modules/trip-planner-api"
+
+  project_name = var.project_name
+  environment  = "prod"
+
+  vpc_cidr = var.vpc_cidr
+  az_count = var.az_count
+
+  image_tag     = var.image_tag
+  desired_count = var.desired_count
+
+  jwt_issuer   = var.jwt_issuer
+  jwt_audience = var.jwt_audience
+  jwt_jwks_url = var.jwt_jwks_url
+
+  public_base_url     = var.public_base_url
+  trust_proxy_headers = var.trust_proxy_headers
+
+  domain_name               = var.domain_name
+  subject_alternative_names = var.subject_alternative_names
+  create_acm_certificate    = var.create_acm_certificate
+  certificate_arn           = var.certificate_arn
+
+  alb_ingress_cidr_blocks = var.alb_ingress_cidr_blocks
+  log_retention_days      = var.log_retention_days
+
+  db_instance_class            = var.db_instance_class
+  db_multi_az                  = var.db_multi_az
+  db_backup_retention_days     = var.db_backup_retention_days
+  db_deletion_protection       = var.db_deletion_protection
+  db_skip_final_snapshot       = var.db_skip_final_snapshot
+  db_final_snapshot_identifier = var.db_final_snapshot_identifier
+
+  secrets_kms_key_arn = var.secrets_kms_key_arn
+
+  tags = merge(var.tags, {
+    Environment = "prod"
+  })
+}

--- a/infra/aws/envs/prod/outputs.tf
+++ b/infra/aws/envs/prod/outputs.tf
@@ -1,0 +1,34 @@
+output "alb_dns_name" {
+  description = "ALB DNS name."
+  value       = module.trip_planner_api.alb_dns_name
+}
+
+output "alb_zone_id" {
+  description = "ALB zone ID."
+  value       = module.trip_planner_api.alb_zone_id
+}
+
+output "ecs_cluster_name" {
+  description = "ECS cluster name."
+  value       = module.trip_planner_api.ecs_cluster_name
+}
+
+output "ecs_service_name" {
+  description = "ECS service name."
+  value       = module.trip_planner_api.ecs_service_name
+}
+
+output "ecr_repository_url" {
+  description = "ECR repository URL."
+  value       = module.trip_planner_api.ecr_repository_url
+}
+
+output "db_secret_arn" {
+  description = "Database secret ARN."
+  value       = module.trip_planner_api.db_secret_arn
+}
+
+output "acm_dns_validation_records" {
+  description = "ACM DNS validation records."
+  value       = module.trip_planner_api.acm_dns_validation_records
+}

--- a/infra/aws/envs/prod/outputs.tf
+++ b/infra/aws/envs/prod/outputs.tf
@@ -13,9 +13,24 @@ output "ecs_cluster_name" {
   value       = module.trip_planner_api.ecs_cluster_name
 }
 
+output "migrations_task_definition_arn" {
+  description = "Migrations task definition ARN."
+  value       = module.trip_planner_api.migrations_task_definition_arn
+}
+
 output "ecs_service_name" {
   description = "ECS service name."
   value       = module.trip_planner_api.ecs_service_name
+}
+
+output "ecs_task_security_group_id" {
+  description = "Security group ID for ECS tasks."
+  value       = module.trip_planner_api.ecs_security_group_id
+}
+
+output "private_subnet_ids_csv" {
+  description = "CSV list of private subnet IDs."
+  value       = join(",", module.trip_planner_api.private_subnet_ids)
 }
 
 output "ecr_repository_url" {

--- a/infra/aws/envs/prod/providers.tf
+++ b/infra/aws/envs/prod/providers.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = var.aws_region
+}

--- a/infra/aws/envs/prod/variables.tf
+++ b/infra/aws/envs/prod/variables.tf
@@ -1,0 +1,146 @@
+variable "project_name" {
+  type        = string
+  description = "Project identifier."
+  default     = "trip-planner-api"
+}
+
+variable "aws_region" {
+  type        = string
+  description = "AWS region."
+  default     = "us-west-2"
+}
+
+variable "vpc_cidr" {
+  type        = string
+  description = "CIDR block for the VPC."
+  default     = "10.1.0.0/16"
+}
+
+variable "az_count" {
+  type        = number
+  description = "Number of availability zones to use."
+  default     = 2
+}
+
+variable "image_tag" {
+  type        = string
+  description = "Container image tag to deploy."
+  default     = "latest"
+}
+
+variable "desired_count" {
+  type        = number
+  description = "Desired ECS task count."
+  default     = 2
+}
+
+variable "jwt_issuer" {
+  type        = string
+  description = "JWT issuer."
+}
+
+variable "jwt_audience" {
+  type        = string
+  description = "JWT audience."
+}
+
+variable "jwt_jwks_url" {
+  type        = string
+  description = "JWKS URL."
+}
+
+variable "public_base_url" {
+  type        = string
+  description = "Public base URL (optional)."
+  default     = ""
+}
+
+variable "trust_proxy_headers" {
+  type        = string
+  description = "Whether to trust proxy headers."
+  default     = "true"
+}
+
+variable "domain_name" {
+  type        = string
+  description = "Domain name for the ALB (optional)."
+  default     = "api.overlandeastbay.com"
+}
+
+variable "subject_alternative_names" {
+  type        = list(string)
+  description = "Subject alternative names for ACM."
+  default     = []
+}
+
+variable "create_acm_certificate" {
+  type        = bool
+  description = "Create ACM certificate in this root."
+  default     = false
+}
+
+variable "certificate_arn" {
+  type        = string
+  description = "Existing ACM certificate ARN to use (optional)."
+  default     = ""
+}
+
+variable "alb_ingress_cidr_blocks" {
+  type        = list(string)
+  description = "CIDR blocks allowed to reach the ALB."
+  default     = ["0.0.0.0/0"]
+}
+
+variable "log_retention_days" {
+  type        = number
+  description = "Log retention in days."
+  default     = 60
+}
+
+variable "db_instance_class" {
+  type        = string
+  description = "RDS instance class."
+  default     = "db.t3.small"
+}
+
+variable "db_multi_az" {
+  type        = bool
+  description = "Enable Multi-AZ for RDS."
+  default     = true
+}
+
+variable "db_backup_retention_days" {
+  type        = number
+  description = "RDS backup retention days."
+  default     = 14
+}
+
+variable "db_deletion_protection" {
+  type        = bool
+  description = "Enable deletion protection."
+  default     = true
+}
+
+variable "db_skip_final_snapshot" {
+  type        = bool
+  description = "Skip final snapshot on destroy."
+  default     = false
+}
+
+variable "db_final_snapshot_identifier" {
+  type        = string
+  description = "Final snapshot identifier when skip_final_snapshot is false."
+  default     = "trip-planner-api-prod-final"
+}
+
+variable "secrets_kms_key_arn" {
+  type        = string
+  description = "Optional KMS key ARN for Secrets Manager."
+  default     = ""
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Extra tags to apply."
+  default     = {}
+}

--- a/infra/aws/envs/prod/variables.tf
+++ b/infra/aws/envs/prod/variables.tf
@@ -28,6 +28,12 @@ variable "image_tag" {
   default     = "latest"
 }
 
+variable "migrations_image_tag" {
+  type        = string
+  description = "Migrations image tag (defaults to image_tag)."
+  default     = ""
+}
+
 variable "desired_count" {
   type        = number
   description = "Desired ECS task count."

--- a/infra/aws/envs/prod/versions.tf
+++ b/infra/aws/envs/prod/versions.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+  }
+
+  backend "s3" {}
+}

--- a/infra/aws/envs/staging/.terraform.lock.hcl
+++ b/infra/aws/envs/staging/.terraform.lock.hcl
@@ -1,0 +1,45 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.8.1"
+  constraints = "~> 3.5"
+  hashes = [
+    "h1:u8AKlWVDTH5r9YLSeswoVEjiY72Rt4/ch7U+61ZDkiQ=",
+    "zh:08dd03b918c7b55713026037c5400c48af5b9f468f483463321bd18e17b907b4",
+    "zh:0eee654a5542dc1d41920bbf2419032d6f0d5625b03bd81339e5b33394a3e0ae",
+    "zh:229665ddf060aa0ed315597908483eee5b818a17d09b6417a0f52fd9405c4f57",
+    "zh:2469d2e48f28076254a2a3fc327f184914566d9e40c5780b8d96ebf7205f8bc0",
+    "zh:37d7eb334d9561f335e748280f5535a384a88675af9a9eac439d4cfd663bcb66",
+    "zh:741101426a2f2c52dee37122f0f4a2f2d6af6d852cb1db634480a86398fa3511",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:a902473f08ef8df62cfe6116bd6c157070a93f66622384300de235a533e9d4a9",
+    "zh:b85c511a23e57a2147355932b3b6dce2a11e856b941165793a0c3d7578d94d05",
+    "zh:c5172226d18eaac95b1daac80172287b69d4ce32750c82ad77fa0768be4ea4b8",
+    "zh:dab4434dba34aad569b0bc243c2d3f3ff86dd7740def373f2a49816bd2ff819b",
+    "zh:f49fd62aa8c5525a5c17abd51e27ca5e213881d58882fd42fec4a545b53c9699",
+  ]
+}

--- a/infra/aws/envs/staging/main.tf
+++ b/infra/aws/envs/staging/main.tf
@@ -7,8 +7,9 @@ module "trip_planner_api" {
   vpc_cidr = var.vpc_cidr
   az_count = var.az_count
 
-  image_tag     = var.image_tag
-  desired_count = var.desired_count
+  image_tag            = var.image_tag
+  migrations_image_tag = var.migrations_image_tag
+  desired_count        = var.desired_count
 
   jwt_issuer   = var.jwt_issuer
   jwt_audience = var.jwt_audience

--- a/infra/aws/envs/staging/main.tf
+++ b/infra/aws/envs/staging/main.tf
@@ -1,0 +1,40 @@
+module "trip_planner_api" {
+  source = "../../modules/trip-planner-api"
+
+  project_name = var.project_name
+  environment  = "staging"
+
+  vpc_cidr = var.vpc_cidr
+  az_count = var.az_count
+
+  image_tag     = var.image_tag
+  desired_count = var.desired_count
+
+  jwt_issuer   = var.jwt_issuer
+  jwt_audience = var.jwt_audience
+  jwt_jwks_url = var.jwt_jwks_url
+
+  public_base_url     = var.public_base_url
+  trust_proxy_headers = var.trust_proxy_headers
+
+  domain_name               = var.domain_name
+  subject_alternative_names = var.subject_alternative_names
+  create_acm_certificate    = var.create_acm_certificate
+  certificate_arn           = var.certificate_arn
+
+  alb_ingress_cidr_blocks = var.alb_ingress_cidr_blocks
+  log_retention_days      = var.log_retention_days
+
+  db_instance_class            = var.db_instance_class
+  db_multi_az                  = var.db_multi_az
+  db_backup_retention_days     = var.db_backup_retention_days
+  db_deletion_protection       = var.db_deletion_protection
+  db_skip_final_snapshot       = var.db_skip_final_snapshot
+  db_final_snapshot_identifier = var.db_final_snapshot_identifier
+
+  secrets_kms_key_arn = var.secrets_kms_key_arn
+
+  tags = merge(var.tags, {
+    Environment = "staging"
+  })
+}

--- a/infra/aws/envs/staging/outputs.tf
+++ b/infra/aws/envs/staging/outputs.tf
@@ -1,0 +1,34 @@
+output "alb_dns_name" {
+  description = "ALB DNS name."
+  value       = module.trip_planner_api.alb_dns_name
+}
+
+output "alb_zone_id" {
+  description = "ALB zone ID."
+  value       = module.trip_planner_api.alb_zone_id
+}
+
+output "ecs_cluster_name" {
+  description = "ECS cluster name."
+  value       = module.trip_planner_api.ecs_cluster_name
+}
+
+output "ecs_service_name" {
+  description = "ECS service name."
+  value       = module.trip_planner_api.ecs_service_name
+}
+
+output "ecr_repository_url" {
+  description = "ECR repository URL."
+  value       = module.trip_planner_api.ecr_repository_url
+}
+
+output "db_secret_arn" {
+  description = "Database secret ARN."
+  value       = module.trip_planner_api.db_secret_arn
+}
+
+output "acm_dns_validation_records" {
+  description = "ACM DNS validation records."
+  value       = module.trip_planner_api.acm_dns_validation_records
+}

--- a/infra/aws/envs/staging/outputs.tf
+++ b/infra/aws/envs/staging/outputs.tf
@@ -13,9 +13,24 @@ output "ecs_cluster_name" {
   value       = module.trip_planner_api.ecs_cluster_name
 }
 
+output "migrations_task_definition_arn" {
+  description = "Migrations task definition ARN."
+  value       = module.trip_planner_api.migrations_task_definition_arn
+}
+
 output "ecs_service_name" {
   description = "ECS service name."
   value       = module.trip_planner_api.ecs_service_name
+}
+
+output "ecs_task_security_group_id" {
+  description = "Security group ID for ECS tasks."
+  value       = module.trip_planner_api.ecs_security_group_id
+}
+
+output "private_subnet_ids_csv" {
+  description = "CSV list of private subnet IDs."
+  value       = join(",", module.trip_planner_api.private_subnet_ids)
 }
 
 output "ecr_repository_url" {

--- a/infra/aws/envs/staging/providers.tf
+++ b/infra/aws/envs/staging/providers.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = var.aws_region
+}

--- a/infra/aws/envs/staging/variables.tf
+++ b/infra/aws/envs/staging/variables.tf
@@ -28,6 +28,12 @@ variable "image_tag" {
   default     = "latest"
 }
 
+variable "migrations_image_tag" {
+  type        = string
+  description = "Migrations image tag (defaults to image_tag)."
+  default     = ""
+}
+
 variable "desired_count" {
   type        = number
   description = "Desired ECS task count."

--- a/infra/aws/envs/staging/variables.tf
+++ b/infra/aws/envs/staging/variables.tf
@@ -1,0 +1,146 @@
+variable "project_name" {
+  type        = string
+  description = "Project identifier."
+  default     = "trip-planner-api"
+}
+
+variable "aws_region" {
+  type        = string
+  description = "AWS region."
+  default     = "us-west-2"
+}
+
+variable "vpc_cidr" {
+  type        = string
+  description = "CIDR block for the VPC."
+  default     = "10.0.0.0/16"
+}
+
+variable "az_count" {
+  type        = number
+  description = "Number of availability zones to use."
+  default     = 2
+}
+
+variable "image_tag" {
+  type        = string
+  description = "Container image tag to deploy."
+  default     = "latest"
+}
+
+variable "desired_count" {
+  type        = number
+  description = "Desired ECS task count."
+  default     = 1
+}
+
+variable "jwt_issuer" {
+  type        = string
+  description = "JWT issuer."
+}
+
+variable "jwt_audience" {
+  type        = string
+  description = "JWT audience."
+}
+
+variable "jwt_jwks_url" {
+  type        = string
+  description = "JWKS URL."
+}
+
+variable "public_base_url" {
+  type        = string
+  description = "Public base URL (optional)."
+  default     = ""
+}
+
+variable "trust_proxy_headers" {
+  type        = string
+  description = "Whether to trust proxy headers."
+  default     = "true"
+}
+
+variable "domain_name" {
+  type        = string
+  description = "Domain name for the ALB (optional)."
+  default     = "api.staging.overlandeastbay.com"
+}
+
+variable "subject_alternative_names" {
+  type        = list(string)
+  description = "Subject alternative names for ACM."
+  default     = []
+}
+
+variable "create_acm_certificate" {
+  type        = bool
+  description = "Create ACM certificate in this root."
+  default     = false
+}
+
+variable "certificate_arn" {
+  type        = string
+  description = "Existing ACM certificate ARN to use (optional)."
+  default     = ""
+}
+
+variable "alb_ingress_cidr_blocks" {
+  type        = list(string)
+  description = "CIDR blocks allowed to reach the ALB."
+  default     = ["0.0.0.0/0"]
+}
+
+variable "log_retention_days" {
+  type        = number
+  description = "Log retention in days."
+  default     = 30
+}
+
+variable "db_instance_class" {
+  type        = string
+  description = "RDS instance class."
+  default     = "db.t3.micro"
+}
+
+variable "db_multi_az" {
+  type        = bool
+  description = "Enable Multi-AZ for RDS."
+  default     = false
+}
+
+variable "db_backup_retention_days" {
+  type        = number
+  description = "RDS backup retention days."
+  default     = 7
+}
+
+variable "db_deletion_protection" {
+  type        = bool
+  description = "Enable deletion protection."
+  default     = false
+}
+
+variable "db_skip_final_snapshot" {
+  type        = bool
+  description = "Skip final snapshot on destroy."
+  default     = true
+}
+
+variable "db_final_snapshot_identifier" {
+  type        = string
+  description = "Final snapshot identifier when skip_final_snapshot is false."
+  default     = ""
+}
+
+variable "secrets_kms_key_arn" {
+  type        = string
+  description = "Optional KMS key ARN for Secrets Manager."
+  default     = ""
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Extra tags to apply."
+  default     = {}
+}

--- a/infra/aws/envs/staging/versions.tf
+++ b/infra/aws/envs/staging/versions.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+  }
+
+  backend "s3" {}
+}

--- a/infra/aws/modules/trip-planner-api/.terraform.lock.hcl
+++ b/infra/aws/modules/trip-planner-api/.terraform.lock.hcl
@@ -1,0 +1,45 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.8.1"
+  constraints = "~> 3.5"
+  hashes = [
+    "h1:u8AKlWVDTH5r9YLSeswoVEjiY72Rt4/ch7U+61ZDkiQ=",
+    "zh:08dd03b918c7b55713026037c5400c48af5b9f468f483463321bd18e17b907b4",
+    "zh:0eee654a5542dc1d41920bbf2419032d6f0d5625b03bd81339e5b33394a3e0ae",
+    "zh:229665ddf060aa0ed315597908483eee5b818a17d09b6417a0f52fd9405c4f57",
+    "zh:2469d2e48f28076254a2a3fc327f184914566d9e40c5780b8d96ebf7205f8bc0",
+    "zh:37d7eb334d9561f335e748280f5535a384a88675af9a9eac439d4cfd663bcb66",
+    "zh:741101426a2f2c52dee37122f0f4a2f2d6af6d852cb1db634480a86398fa3511",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:a902473f08ef8df62cfe6116bd6c157070a93f66622384300de235a533e9d4a9",
+    "zh:b85c511a23e57a2147355932b3b6dce2a11e856b941165793a0c3d7578d94d05",
+    "zh:c5172226d18eaac95b1daac80172287b69d4ce32750c82ad77fa0768be4ea4b8",
+    "zh:dab4434dba34aad569b0bc243c2d3f3ff86dd7740def373f2a49816bd2ff819b",
+    "zh:f49fd62aa8c5525a5c17abd51e27ca5e213881d58882fd42fec4a545b53c9699",
+  ]
+}

--- a/infra/aws/modules/trip-planner-api/main.tf
+++ b/infra/aws/modules/trip-planner-api/main.tf
@@ -16,6 +16,8 @@ locals {
     for idx in range(var.az_count) : cidrsubnet(var.vpc_cidr, 8, idx + var.az_count)
   ]
 
+  migrations_image_tag = var.migrations_image_tag != "" ? var.migrations_image_tag : var.image_tag
+
   enable_tls = var.certificate_arn != "" || var.create_acm_certificate
   tls_certificate_arn = var.certificate_arn != "" ? var.certificate_arn : (
     var.create_acm_certificate ? aws_acm_certificate.app[0].arn : ""
@@ -224,6 +226,15 @@ resource "aws_cloudwatch_log_group" "app" {
 
   tags = merge(var.tags, {
     Name = "${local.name_prefix}-logs"
+  })
+}
+
+resource "aws_cloudwatch_log_group" "migrations" {
+  name              = "/ecs/${local.name_prefix}-migrations"
+  retention_in_days = var.log_retention_days
+
+  tags = merge(var.tags, {
+    Name = "${local.name_prefix}-migrations-logs"
   })
 }
 
@@ -491,6 +502,38 @@ resource "aws_ecs_task_definition" "app" {
         logDriver = "awslogs"
         options = {
           awslogs-group         = aws_cloudwatch_log_group.app.name
+          awslogs-region        = data.aws_region.current.name
+          awslogs-stream-prefix = "ecs"
+        }
+      }
+    }
+  ])
+}
+
+resource "aws_ecs_task_definition" "migrations" {
+  family                   = "${local.name_prefix}-migrations"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = var.migrations_task_cpu
+  memory                   = var.migrations_task_memory
+  execution_role_arn       = aws_iam_role.task_execution.arn
+  task_role_arn            = aws_iam_role.task.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "migrations"
+      image     = "${aws_ecr_repository.app.repository_url}:${local.migrations_image_tag}"
+      essential = true
+      secrets = [
+        {
+          name      = "DATABASE_URL"
+          valueFrom = "${aws_secretsmanager_secret.db_credentials.arn}:database_url::"
+        }
+      ]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.migrations.name
           awslogs-region        = data.aws_region.current.name
           awslogs-stream-prefix = "ecs"
         }

--- a/infra/aws/modules/trip-planner-api/main.tf
+++ b/infra/aws/modules/trip-planner-api/main.tf
@@ -1,0 +1,535 @@
+data "aws_region" "current" {}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+locals {
+  name_prefix = "${var.project_name}-${var.environment}"
+  azs         = slice(data.aws_availability_zones.available.names, 0, var.az_count)
+
+  public_subnet_cidrs = length(var.public_subnet_cidrs) > 0 ? var.public_subnet_cidrs : [
+    for idx in range(var.az_count) : cidrsubnet(var.vpc_cidr, 8, idx)
+  ]
+
+  private_subnet_cidrs = length(var.private_subnet_cidrs) > 0 ? var.private_subnet_cidrs : [
+    for idx in range(var.az_count) : cidrsubnet(var.vpc_cidr, 8, idx + var.az_count)
+  ]
+
+  enable_tls = var.certificate_arn != "" || var.create_acm_certificate
+  tls_certificate_arn = var.certificate_arn != "" ? var.certificate_arn : (
+    var.create_acm_certificate ? aws_acm_certificate.app[0].arn : ""
+  )
+
+  database_url  = "postgres://${var.db_username}:${random_password.db.result}@${aws_db_instance.postgres.address}:${var.db_port}/${var.db_name}?sslmode=require"
+  http_redirect = local.enable_tls && var.enable_http_to_https_redirect
+}
+
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = merge(var.tags, {
+    Name = "${local.name_prefix}-vpc"
+  })
+}
+
+resource "aws_internet_gateway" "igw" {
+  vpc_id = aws_vpc.main.id
+
+  tags = merge(var.tags, {
+    Name = "${local.name_prefix}-igw"
+  })
+}
+
+resource "aws_subnet" "public" {
+  count                   = var.az_count
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = local.public_subnet_cidrs[count.index]
+  availability_zone       = local.azs[count.index]
+  map_public_ip_on_launch = true
+
+  tags = merge(var.tags, {
+    Name = "${local.name_prefix}-public-${count.index + 1}"
+  })
+}
+
+resource "aws_subnet" "private" {
+  count             = var.az_count
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = local.private_subnet_cidrs[count.index]
+  availability_zone = local.azs[count.index]
+
+  tags = merge(var.tags, {
+    Name = "${local.name_prefix}-private-${count.index + 1}"
+  })
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.igw.id
+  }
+
+  tags = merge(var.tags, {
+    Name = "${local.name_prefix}-public-rt"
+  })
+}
+
+resource "aws_route_table_association" "public" {
+  count          = var.az_count
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_eip" "nat" {
+  domain = "vpc"
+
+  tags = merge(var.tags, {
+    Name = "${local.name_prefix}-nat-eip"
+  })
+}
+
+resource "aws_nat_gateway" "nat" {
+  allocation_id = aws_eip.nat.id
+  subnet_id     = aws_subnet.public[0].id
+
+  tags = merge(var.tags, {
+    Name = "${local.name_prefix}-nat"
+  })
+
+  depends_on = [aws_internet_gateway.igw]
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.nat.id
+  }
+
+  tags = merge(var.tags, {
+    Name = "${local.name_prefix}-private-rt"
+  })
+}
+
+resource "aws_route_table_association" "private" {
+  count          = var.az_count
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private.id
+}
+
+resource "aws_security_group" "alb" {
+  name        = "${local.name_prefix}-alb"
+  description = "ALB ingress"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = var.alb_ingress_cidr_blocks
+  }
+
+  dynamic "ingress" {
+    for_each = local.enable_tls ? [443] : []
+    content {
+      from_port   = ingress.value
+      to_port     = ingress.value
+      protocol    = "tcp"
+      cidr_blocks = var.alb_ingress_cidr_blocks
+    }
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(var.tags, {
+    Name = "${local.name_prefix}-alb-sg"
+  })
+}
+
+resource "aws_security_group" "ecs" {
+  name        = "${local.name_prefix}-ecs"
+  description = "ECS task ingress"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port       = var.container_port
+    to_port         = var.container_port
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(var.tags, {
+    Name = "${local.name_prefix}-ecs-sg"
+  })
+}
+
+resource "aws_security_group" "db" {
+  name        = "${local.name_prefix}-db"
+  description = "RDS ingress"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port       = var.db_port
+    to_port         = var.db_port
+    protocol        = "tcp"
+    security_groups = [aws_security_group.ecs.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(var.tags, {
+    Name = "${local.name_prefix}-db-sg"
+  })
+}
+
+resource "aws_ecr_repository" "app" {
+  name                 = local.name_prefix
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = merge(var.tags, {
+    Name = "${local.name_prefix}-ecr"
+  })
+}
+
+resource "aws_cloudwatch_log_group" "app" {
+  name              = "/ecs/${local.name_prefix}"
+  retention_in_days = var.log_retention_days
+
+  tags = merge(var.tags, {
+    Name = "${local.name_prefix}-logs"
+  })
+}
+
+resource "aws_secretsmanager_secret" "db_credentials" {
+  name       = "/${var.project_name}/${var.environment}/database"
+  kms_key_id = var.secrets_kms_key_arn != "" ? var.secrets_kms_key_arn : null
+
+  tags = merge(var.tags, {
+    Name = "${local.name_prefix}-db-secret"
+  })
+}
+
+resource "random_password" "db" {
+  length  = 32
+  special = false
+}
+
+resource "aws_db_subnet_group" "db" {
+  name       = "${local.name_prefix}-db-subnets"
+  subnet_ids = aws_subnet.private[*].id
+
+  tags = merge(var.tags, {
+    Name = "${local.name_prefix}-db-subnets"
+  })
+}
+
+resource "aws_db_instance" "postgres" {
+  identifier                 = "${local.name_prefix}-db"
+  engine                     = "postgres"
+  engine_version             = var.db_engine_version
+  instance_class             = var.db_instance_class
+  allocated_storage          = var.db_allocated_storage
+  max_allocated_storage      = var.db_max_allocated_storage
+  storage_type               = var.db_storage_type
+  storage_encrypted          = true
+  db_name                    = var.db_name
+  username                   = var.db_username
+  password                   = random_password.db.result
+  port                       = var.db_port
+  db_subnet_group_name       = aws_db_subnet_group.db.name
+  vpc_security_group_ids     = [aws_security_group.db.id]
+  multi_az                   = var.db_multi_az
+  backup_retention_period    = var.db_backup_retention_days
+  deletion_protection        = var.db_deletion_protection
+  skip_final_snapshot        = var.db_skip_final_snapshot
+  final_snapshot_identifier  = var.db_skip_final_snapshot ? null : var.db_final_snapshot_identifier
+  publicly_accessible        = var.db_publicly_accessible
+  apply_immediately          = var.db_apply_immediately
+  auto_minor_version_upgrade = true
+
+  tags = merge(var.tags, {
+    Name = "${local.name_prefix}-db"
+  })
+}
+
+resource "aws_secretsmanager_secret_version" "db_credentials" {
+  secret_id = aws_secretsmanager_secret.db_credentials.id
+
+  secret_string = jsonencode({
+    username     = var.db_username
+    password     = random_password.db.result
+    host         = aws_db_instance.postgres.address
+    port         = var.db_port
+    dbname       = var.db_name
+    database_url = local.database_url
+  })
+}
+
+data "aws_iam_policy_document" "ecs_task_assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "task_execution" {
+  name               = "${local.name_prefix}-task-exec"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_assume.json
+}
+
+resource "aws_iam_role" "task" {
+  name               = "${local.name_prefix}-task"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "task_execution_default" {
+  role       = aws_iam_role.task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+data "aws_iam_policy_document" "task_execution_secrets" {
+  statement {
+    effect    = "Allow"
+    actions   = ["secretsmanager:GetSecretValue"]
+    resources = [aws_secretsmanager_secret.db_credentials.arn]
+  }
+
+  dynamic "statement" {
+    for_each = var.secrets_kms_key_arn != "" ? [var.secrets_kms_key_arn] : []
+    content {
+      effect    = "Allow"
+      actions   = ["kms:Decrypt"]
+      resources = [statement.value]
+    }
+  }
+}
+
+resource "aws_iam_policy" "task_execution_secrets" {
+  name   = "${local.name_prefix}-secrets"
+  policy = data.aws_iam_policy_document.task_execution_secrets.json
+}
+
+resource "aws_iam_role_policy_attachment" "task_execution_secrets" {
+  role       = aws_iam_role.task_execution.name
+  policy_arn = aws_iam_policy.task_execution_secrets.arn
+}
+
+resource "aws_ecs_cluster" "app" {
+  name = local.name_prefix
+
+  setting {
+    name  = "containerInsights"
+    value = var.enable_container_insights ? "enabled" : "disabled"
+  }
+
+  tags = merge(var.tags, {
+    Name = "${local.name_prefix}-cluster"
+  })
+}
+
+resource "aws_lb" "app" {
+  name                       = "${local.name_prefix}-alb"
+  load_balancer_type         = "application"
+  subnets                    = aws_subnet.public[*].id
+  security_groups            = [aws_security_group.alb.id]
+  enable_deletion_protection = var.alb_deletion_protection
+
+  tags = merge(var.tags, {
+    Name = "${local.name_prefix}-alb"
+  })
+}
+
+resource "aws_lb_target_group" "app" {
+  name        = "${local.name_prefix}-tg"
+  port        = var.container_port
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.main.id
+  target_type = "ip"
+
+  health_check {
+    path                = var.health_check_path
+    matcher             = "200-399"
+    interval            = 30
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+  }
+
+  tags = merge(var.tags, {
+    Name = "${local.name_prefix}-tg"
+  })
+}
+
+resource "aws_acm_certificate" "app" {
+  count                     = var.create_acm_certificate ? 1 : 0
+  domain_name               = var.domain_name
+  validation_method         = "DNS"
+  subject_alternative_names = var.subject_alternative_names
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = merge(var.tags, {
+    Name = "${local.name_prefix}-cert"
+  })
+}
+
+resource "aws_lb_listener" "http_forward" {
+  count             = local.http_redirect ? 0 : 1
+  load_balancer_arn = aws_lb.app.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.app.arn
+  }
+}
+
+resource "aws_lb_listener" "http_redirect" {
+  count             = local.http_redirect ? 1 : 0
+  load_balancer_arn = aws_lb.app.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+resource "aws_lb_listener" "https" {
+  count             = local.enable_tls ? 1 : 0
+  load_balancer_arn = aws_lb.app.arn
+  port              = 443
+  protocol          = "HTTPS"
+  certificate_arn   = local.tls_certificate_arn
+  ssl_policy        = "ELBSecurityPolicy-2016-08"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.app.arn
+  }
+}
+
+resource "aws_ecs_task_definition" "app" {
+  family                   = local.name_prefix
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = var.task_cpu
+  memory                   = var.task_memory
+  execution_role_arn       = aws_iam_role.task_execution.arn
+  task_role_arn            = aws_iam_role.task.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "app"
+      image     = "${aws_ecr_repository.app.repository_url}:${var.image_tag}"
+      essential = true
+      portMappings = [
+        {
+          containerPort = var.container_port
+          hostPort      = var.container_port
+          protocol      = "tcp"
+        }
+      ]
+      environment = [
+        { name = "PORT", value = tostring(var.container_port) },
+        { name = "STORAGE_BACKEND", value = var.storage_backend },
+        { name = "AUTH_MODE", value = var.auth_mode },
+        { name = "JWT_ISSUER", value = var.jwt_issuer },
+        { name = "JWT_AUDIENCE", value = var.jwt_audience },
+        { name = "JWT_JWKS_URL", value = var.jwt_jwks_url },
+        { name = "PUBLIC_BASE_URL", value = var.public_base_url },
+        { name = "TRUST_PROXY_HEADERS", value = var.trust_proxy_headers },
+      ]
+      secrets = [
+        {
+          name      = "DATABASE_URL"
+          valueFrom = "${aws_secretsmanager_secret.db_credentials.arn}:database_url::"
+        }
+      ]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.app.name
+          awslogs-region        = data.aws_region.current.name
+          awslogs-stream-prefix = "ecs"
+        }
+      }
+    }
+  ])
+}
+
+resource "aws_ecs_service" "app" {
+  name                   = local.name_prefix
+  cluster                = aws_ecs_cluster.app.id
+  task_definition        = aws_ecs_task_definition.app.arn
+  desired_count          = var.desired_count
+  launch_type            = "FARGATE"
+  enable_execute_command = var.enable_execute_command
+
+  deployment_minimum_healthy_percent = 50
+  deployment_maximum_percent         = 200
+  health_check_grace_period_seconds  = 60
+
+  network_configuration {
+    subnets          = aws_subnet.private[*].id
+    security_groups  = [aws_security_group.ecs.id]
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.app.arn
+    container_name   = "app"
+    container_port   = var.container_port
+  }
+
+  tags = merge(var.tags, {
+    Name = "${local.name_prefix}-service"
+  })
+
+  depends_on = [
+    aws_lb_listener.http_forward,
+    aws_lb_listener.http_redirect,
+    aws_lb_listener.https
+  ]
+}

--- a/infra/aws/modules/trip-planner-api/outputs.tf
+++ b/infra/aws/modules/trip-planner-api/outputs.tf
@@ -13,6 +13,11 @@ output "private_subnet_ids" {
   value       = aws_subnet.private[*].id
 }
 
+output "ecs_security_group_id" {
+  description = "Security group ID for ECS tasks."
+  value       = aws_security_group.ecs.id
+}
+
 output "alb_dns_name" {
   description = "ALB DNS name."
   value       = aws_lb.app.dns_name
@@ -31,6 +36,11 @@ output "ecs_cluster_name" {
 output "ecs_service_name" {
   description = "ECS service name."
   value       = aws_ecs_service.app.name
+}
+
+output "migrations_task_definition_arn" {
+  description = "ECS task definition ARN for migrations."
+  value       = aws_ecs_task_definition.migrations.arn
 }
 
 output "ecr_repository_url" {

--- a/infra/aws/modules/trip-planner-api/outputs.tf
+++ b/infra/aws/modules/trip-planner-api/outputs.tf
@@ -1,0 +1,59 @@
+output "vpc_id" {
+  description = "VPC ID."
+  value       = aws_vpc.main.id
+}
+
+output "public_subnet_ids" {
+  description = "Public subnet IDs."
+  value       = aws_subnet.public[*].id
+}
+
+output "private_subnet_ids" {
+  description = "Private subnet IDs."
+  value       = aws_subnet.private[*].id
+}
+
+output "alb_dns_name" {
+  description = "ALB DNS name."
+  value       = aws_lb.app.dns_name
+}
+
+output "alb_zone_id" {
+  description = "ALB hosted zone ID."
+  value       = aws_lb.app.zone_id
+}
+
+output "ecs_cluster_name" {
+  description = "ECS cluster name."
+  value       = aws_ecs_cluster.app.name
+}
+
+output "ecs_service_name" {
+  description = "ECS service name."
+  value       = aws_ecs_service.app.name
+}
+
+output "ecr_repository_url" {
+  description = "ECR repository URL."
+  value       = aws_ecr_repository.app.repository_url
+}
+
+output "db_instance_endpoint" {
+  description = "RDS instance endpoint."
+  value       = aws_db_instance.postgres.address
+}
+
+output "db_secret_arn" {
+  description = "Secrets Manager ARN with database credentials."
+  value       = aws_secretsmanager_secret.db_credentials.arn
+}
+
+output "acm_dns_validation_records" {
+  description = "DNS validation records for ACM certificate."
+  value       = var.create_acm_certificate ? aws_acm_certificate.app[0].domain_validation_options : []
+}
+
+output "certificate_arn" {
+  description = "ACM certificate ARN in use."
+  value       = local.tls_certificate_arn
+}

--- a/infra/aws/modules/trip-planner-api/variables.tf
+++ b/infra/aws/modules/trip-planner-api/variables.tf
@@ -56,6 +56,18 @@ variable "task_memory" {
   default     = "512"
 }
 
+variable "migrations_task_cpu" {
+  type        = string
+  description = "Fargate task CPU units for migrations."
+  default     = "256"
+}
+
+variable "migrations_task_memory" {
+  type        = string
+  description = "Fargate task memory (MiB) for migrations."
+  default     = "512"
+}
+
 variable "desired_count" {
   type        = number
   description = "Desired number of ECS tasks."
@@ -66,6 +78,12 @@ variable "image_tag" {
   type        = string
   description = "Container image tag to deploy."
   default     = "latest"
+}
+
+variable "migrations_image_tag" {
+  type        = string
+  description = "Container image tag for migrations (defaults to image_tag)."
+  default     = ""
 }
 
 variable "health_check_path" {

--- a/infra/aws/modules/trip-planner-api/variables.tf
+++ b/infra/aws/modules/trip-planner-api/variables.tf
@@ -1,0 +1,298 @@
+variable "project_name" {
+  type        = string
+  description = "Short project identifier used in resource names."
+}
+
+variable "environment" {
+  type        = string
+  description = "Deployment environment name (e.g., staging, prod)."
+}
+
+variable "vpc_cidr" {
+  type        = string
+  description = "CIDR block for the VPC."
+  default     = "10.0.0.0/16"
+}
+
+variable "az_count" {
+  type        = number
+  description = "Number of availability zones to use."
+  default     = 2
+}
+
+variable "public_subnet_cidrs" {
+  type        = list(string)
+  description = "Optional explicit CIDRs for public subnets."
+  default     = []
+}
+
+variable "private_subnet_cidrs" {
+  type        = list(string)
+  description = "Optional explicit CIDRs for private subnets."
+  default     = []
+}
+
+variable "alb_ingress_cidr_blocks" {
+  type        = list(string)
+  description = "CIDR blocks allowed to reach the ALB."
+  default     = ["0.0.0.0/0"]
+}
+
+variable "container_port" {
+  type        = number
+  description = "Container port exposed by the API."
+  default     = 8080
+}
+
+variable "task_cpu" {
+  type        = string
+  description = "Fargate task CPU units."
+  default     = "256"
+}
+
+variable "task_memory" {
+  type        = string
+  description = "Fargate task memory (MiB)."
+  default     = "512"
+}
+
+variable "desired_count" {
+  type        = number
+  description = "Desired number of ECS tasks."
+  default     = 2
+}
+
+variable "image_tag" {
+  type        = string
+  description = "Container image tag to deploy."
+  default     = "latest"
+}
+
+variable "health_check_path" {
+  type        = string
+  description = "Health check path for the target group."
+  default     = "/healthz"
+}
+
+variable "log_retention_days" {
+  type        = number
+  description = "CloudWatch log group retention in days."
+  default     = 30
+}
+
+variable "enable_execute_command" {
+  type        = bool
+  description = "Enable ECS execute command support."
+  default     = true
+}
+
+variable "enable_container_insights" {
+  type        = bool
+  description = "Enable ECS container insights."
+  default     = true
+}
+
+variable "storage_backend" {
+  type        = string
+  description = "Storage backend for the API."
+  default     = "postgres"
+}
+
+variable "auth_mode" {
+  type        = string
+  description = "Authentication mode (jwt or dev)."
+  default     = "jwt"
+}
+
+variable "jwt_issuer" {
+  type        = string
+  description = "JWT issuer for auth verification."
+  default     = ""
+
+  validation {
+    condition     = var.auth_mode != "jwt" || var.jwt_issuer != ""
+    error_message = "jwt_issuer is required when auth_mode is jwt."
+  }
+}
+
+variable "jwt_audience" {
+  type        = string
+  description = "JWT audience for auth verification."
+  default     = ""
+
+  validation {
+    condition     = var.auth_mode != "jwt" || var.jwt_audience != ""
+    error_message = "jwt_audience is required when auth_mode is jwt."
+  }
+}
+
+variable "jwt_jwks_url" {
+  type        = string
+  description = "JWT JWKS URL for auth verification."
+  default     = ""
+
+  validation {
+    condition     = var.auth_mode != "jwt" || var.jwt_jwks_url != ""
+    error_message = "jwt_jwks_url is required when auth_mode is jwt."
+  }
+}
+
+variable "public_base_url" {
+  type        = string
+  description = "Public base URL for the API (optional)."
+  default     = ""
+}
+
+variable "trust_proxy_headers" {
+  type        = string
+  description = "Whether to trust proxy headers."
+  default     = "true"
+}
+
+variable "db_name" {
+  type        = string
+  description = "Database name."
+  default     = "tripplanner"
+}
+
+variable "db_username" {
+  type        = string
+  description = "Database master username."
+  default     = "ebo"
+}
+
+variable "db_port" {
+  type        = number
+  description = "Database port."
+  default     = 5432
+}
+
+variable "db_instance_class" {
+  type        = string
+  description = "RDS instance class."
+  default     = "db.t3.micro"
+}
+
+variable "db_engine_version" {
+  type        = string
+  description = "Postgres engine version."
+  default     = "15.5"
+}
+
+variable "db_allocated_storage" {
+  type        = number
+  description = "Allocated storage (GiB)."
+  default     = 20
+}
+
+variable "db_max_allocated_storage" {
+  type        = number
+  description = "Maximum autoscaled storage (GiB)."
+  default     = 100
+}
+
+variable "db_backup_retention_days" {
+  type        = number
+  description = "Backup retention in days."
+  default     = 7
+}
+
+variable "db_storage_type" {
+  type        = string
+  description = "RDS storage type."
+  default     = "gp3"
+}
+
+variable "db_multi_az" {
+  type        = bool
+  description = "Enable Multi-AZ RDS."
+  default     = false
+}
+
+variable "db_deletion_protection" {
+  type        = bool
+  description = "Enable RDS deletion protection."
+  default     = false
+}
+
+variable "db_skip_final_snapshot" {
+  type        = bool
+  description = "Skip final snapshot on destroy."
+  default     = true
+}
+
+variable "db_final_snapshot_identifier" {
+  type        = string
+  description = "Final snapshot identifier when skip_final_snapshot is false."
+  default     = ""
+
+  validation {
+    condition     = var.db_skip_final_snapshot || var.db_final_snapshot_identifier != ""
+    error_message = "db_final_snapshot_identifier is required when db_skip_final_snapshot is false."
+  }
+}
+
+variable "db_apply_immediately" {
+  type        = bool
+  description = "Apply DB changes immediately."
+  default     = true
+}
+
+variable "db_publicly_accessible" {
+  type        = bool
+  description = "Whether the RDS instance is publicly accessible."
+  default     = false
+}
+
+variable "secrets_kms_key_arn" {
+  type        = string
+  description = "Optional KMS key ARN for Secrets Manager."
+  default     = ""
+}
+
+variable "domain_name" {
+  type        = string
+  description = "Optional domain name for the ALB."
+  default     = ""
+}
+
+variable "subject_alternative_names" {
+  type        = list(string)
+  description = "Subject alternative names for the ACM certificate."
+  default     = []
+}
+
+variable "create_acm_certificate" {
+  type        = bool
+  description = "Whether to create an ACM certificate in this module."
+  default     = false
+
+  validation {
+    condition     = !var.create_acm_certificate || var.domain_name != ""
+    error_message = "domain_name must be set when create_acm_certificate is true."
+  }
+}
+
+variable "certificate_arn" {
+  type        = string
+  description = "Existing ACM certificate ARN to use for HTTPS."
+  default     = ""
+}
+
+variable "enable_http_to_https_redirect" {
+  type        = bool
+  description = "Redirect HTTP to HTTPS when TLS is enabled."
+  default     = true
+}
+
+variable "alb_deletion_protection" {
+  type        = bool
+  description = "Enable deletion protection on the ALB."
+  default     = false
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Additional tags applied to all resources."
+  default     = {}
+}

--- a/infra/aws/modules/trip-planner-api/versions.tf
+++ b/infra/aws/modules/trip-planner-api/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+  }
+}

--- a/infra/bootstrap/.terraform.lock.hcl
+++ b/infra/bootstrap/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/bootstrap/README.md
+++ b/infra/bootstrap/README.md
@@ -1,0 +1,54 @@
+# Terraform bootstrap (state + GitHub OIDC)
+
+This root provisions the shared AWS prerequisites used by all environments:
+
+- S3 bucket for Terraform state
+- DynamoDB table for state locking
+- GitHub OIDC provider
+- GitHub deploy roles for `staging` and `prod`
+
+## Prereqs
+
+- Terraform >= 1.6
+- AWS credentials with permissions to create S3, DynamoDB, IAM, and OIDC providers
+
+## One-time apply
+
+```bash
+cd infra/bootstrap
+terraform init
+terraform apply \
+  -var "aws_region=us-west-2" \
+  -var "tfstate_bucket_name=trip-planner-api-tfstate" \
+  -var "tfstate_lock_table_name=trip-planner-api-tfstate-lock" \
+  -var "github_org=Overland-East-Bay" \
+  -var "github_repo=trip-planner-api"
+```
+
+If you use GitHub Environments for OIDC scoping, keep the default `github_subjects`
+map; otherwise override it to match your branch-based policy.
+
+## Next steps (environment roots)
+
+Use the outputs to configure remote state in environment roots:
+
+```hcl
+terraform {
+  backend "s3" {
+    bucket         = "<tfstate_bucket_name>"
+    key            = "aws/<environment>/terraform.tfstate"
+    region         = "<aws_region>"
+    dynamodb_table = "<tfstate_lock_table_name>"
+    encrypt        = true
+  }
+}
+```
+
+## GitHub Actions configuration (names only)
+
+Create GitHub Environments named `staging` and `prod`, then add variables/secrets:
+
+- `AWS_REGION` (matches `aws_region`)
+- `AWS_ROLE_ARN` (from `deploy_role_arns` output per environment)
+
+No long-lived AWS keys should be stored in the repo or GitHub secrets.

--- a/infra/bootstrap/main.tf
+++ b/infra/bootstrap/main.tf
@@ -1,0 +1,120 @@
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = merge(
+      {
+        Project    = var.project_name
+        ManagedBy  = "terraform"
+        Repository = "${var.github_org}/${var.github_repo}"
+      },
+      var.tags
+    )
+  }
+}
+
+resource "aws_s3_bucket" "tf_state" {
+  bucket        = var.tfstate_bucket_name
+  force_destroy = var.tfstate_bucket_force_destroy
+}
+
+resource "aws_s3_bucket_versioning" "tf_state" {
+  bucket = aws_s3_bucket.tf_state.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "tf_state" {
+  bucket = aws_s3_bucket.tf_state.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "tf_state" {
+  bucket = aws_s3_bucket.tf_state.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_ownership_controls" "tf_state" {
+  bucket = aws_s3_bucket.tf_state.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_dynamodb_table" "tf_lock" {
+  name         = var.tfstate_lock_table_name
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+}
+
+resource "aws_iam_openid_connect_provider" "github" {
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = var.github_oidc_thumbprints
+}
+
+data "aws_iam_policy_document" "github_assume_role" {
+  for_each = var.github_subjects
+
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github.arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = each.value
+    }
+  }
+}
+
+resource "aws_iam_role" "github_deploy" {
+  for_each = var.github_subjects
+
+  name               = "${var.project_name}-${each.key}-deploy"
+  assume_role_policy = data.aws_iam_policy_document.github_assume_role[each.key].json
+}
+
+locals {
+  deploy_role_policy_bindings = {
+    for pair in setproduct(keys(var.github_subjects), var.deploy_role_policy_arns) :
+    "${pair[0]}-${md5(pair[1])}" => {
+      env        = pair[0]
+      policy_arn = pair[1]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "github_deploy" {
+  for_each   = local.deploy_role_policy_bindings
+  role       = aws_iam_role.github_deploy[each.value.env].name
+  policy_arn = each.value.policy_arn
+}

--- a/infra/bootstrap/outputs.tf
+++ b/infra/bootstrap/outputs.tf
@@ -1,0 +1,22 @@
+output "tfstate_bucket_name" {
+  description = "S3 bucket used for Terraform state."
+  value       = aws_s3_bucket.tf_state.bucket
+}
+
+output "tfstate_lock_table_name" {
+  description = "DynamoDB table used for Terraform state locking."
+  value       = aws_dynamodb_table.tf_lock.name
+}
+
+output "github_oidc_provider_arn" {
+  description = "OIDC provider ARN for GitHub Actions."
+  value       = aws_iam_openid_connect_provider.github.arn
+}
+
+output "deploy_role_arns" {
+  description = "Map of environment to GitHub deploy role ARN."
+  value = {
+    for env, role in aws_iam_role.github_deploy :
+    env => role.arn
+  }
+}

--- a/infra/bootstrap/variables.tf
+++ b/infra/bootstrap/variables.tf
@@ -1,0 +1,68 @@
+variable "project_name" {
+  type        = string
+  description = "Short project identifier used in resource names."
+  default     = "trip-planner-api"
+}
+
+variable "aws_region" {
+  type        = string
+  description = "AWS region for all bootstrap resources."
+  default     = "us-west-2"
+}
+
+variable "tfstate_bucket_name" {
+  type        = string
+  description = "S3 bucket name for Terraform state."
+  default     = "trip-planner-api-tfstate"
+}
+
+variable "tfstate_bucket_force_destroy" {
+  type        = bool
+  description = "Allow force-destroying the tfstate bucket (use only for teardown)."
+  default     = false
+}
+
+variable "tfstate_lock_table_name" {
+  type        = string
+  description = "DynamoDB table name for Terraform state locks."
+  default     = "trip-planner-api-tfstate-lock"
+}
+
+variable "github_org" {
+  type        = string
+  description = "GitHub organization or user that owns the repository."
+  default     = "Overland-East-Bay"
+}
+
+variable "github_repo" {
+  type        = string
+  description = "GitHub repository name."
+  default     = "trip-planner-api"
+}
+
+variable "github_subjects" {
+  type        = map(list(string))
+  description = "Map of environment to allowed OIDC subject patterns."
+  default = {
+    staging = ["repo:Overland-East-Bay/trip-planner-api:environment:staging"]
+    prod    = ["repo:Overland-East-Bay/trip-planner-api:environment:prod"]
+  }
+}
+
+variable "github_oidc_thumbprints" {
+  type        = list(string)
+  description = "Thumbprints for the GitHub OIDC provider."
+  default     = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+}
+
+variable "deploy_role_policy_arns" {
+  type        = list(string)
+  description = "Managed policy ARNs attached to the GitHub deploy roles."
+  default     = ["arn:aws:iam::aws:policy/AdministratorAccess"]
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Additional tags applied to all resources."
+  default     = {}
+}

--- a/infra/bootstrap/versions.tf
+++ b/infra/bootstrap/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/infra/local/.terraform.lock.hcl
+++ b/infra/local/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/local/main.tf
+++ b/infra/local/main.tf
@@ -1,0 +1,236 @@
+provider "aws" {
+  region                      = var.aws_region
+  access_key                  = "test"
+  secret_key                  = "test"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+
+  endpoints {
+    cloudwatch     = var.localstack_endpoint
+    cloudwatchlogs = var.localstack_endpoint
+    ec2            = var.localstack_endpoint
+    ecr            = var.localstack_endpoint
+    ecs            = var.localstack_endpoint
+    iam            = var.localstack_endpoint
+    logs           = var.localstack_endpoint
+    secretsmanager = var.localstack_endpoint
+    sts            = var.localstack_endpoint
+  }
+}
+
+locals {
+  name_prefix      = "${var.project_name}-local"
+  repository_name  = var.ecr_repository_name != "" ? var.ecr_repository_name : "${var.project_name}-local"
+  app_image        = "${var.image_registry}/${local.repository_name}:${var.image_tag}"
+  migrations_image = "${var.image_registry}/${local.repository_name}:${var.migrations_image_tag}"
+
+  private_subnet_cidrs = [
+    for idx in range(var.az_count) : cidrsubnet(var.vpc_cidr, 8, idx)
+  ]
+}
+
+resource "aws_vpc" "local" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = merge(var.tags, {
+    Name = "${local.name_prefix}-vpc"
+  })
+}
+
+resource "aws_subnet" "private" {
+  count             = var.az_count
+  vpc_id            = aws_vpc.local.id
+  cidr_block        = local.private_subnet_cidrs[count.index]
+  availability_zone = "${var.aws_region}${count.index == 0 ? "a" : "b"}"
+
+  tags = merge(var.tags, {
+    Name = "${local.name_prefix}-subnet-${count.index + 1}"
+  })
+}
+
+resource "aws_security_group" "ecs" {
+  name        = "${local.name_prefix}-ecs"
+  description = "LocalStack ECS task ingress"
+  vpc_id      = aws_vpc.local.id
+
+  ingress {
+    from_port   = 8080
+    to_port     = 8080
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(var.tags, {
+    Name = "${local.name_prefix}-ecs-sg"
+  })
+}
+
+resource "aws_ecr_repository" "app" {
+  name                 = local.repository_name
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+resource "aws_cloudwatch_log_group" "app" {
+  name              = "/ecs/${local.name_prefix}"
+  retention_in_days = 7
+}
+
+resource "aws_cloudwatch_log_group" "migrations" {
+  name              = "/ecs/${local.name_prefix}-migrations"
+  retention_in_days = 7
+}
+
+resource "aws_secretsmanager_secret" "db" {
+  name = "/${var.project_name}/local/database"
+}
+
+resource "aws_secretsmanager_secret_version" "db" {
+  secret_id = aws_secretsmanager_secret.db.id
+  secret_string = jsonencode({
+    database_url = var.database_url
+  })
+}
+
+data "aws_iam_policy_document" "ecs_task_assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "task_execution" {
+  name               = "${local.name_prefix}-task-exec"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_assume.json
+}
+
+resource "aws_iam_role" "task" {
+  name               = "${local.name_prefix}-task"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_assume.json
+}
+
+data "aws_iam_policy_document" "task_execution" {
+  statement {
+    effect    = "Allow"
+    actions   = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"]
+    resources = ["*"]
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["secretsmanager:GetSecretValue"]
+    resources = [aws_secretsmanager_secret.db.arn]
+  }
+}
+
+resource "aws_iam_role_policy" "task_execution" {
+  role   = aws_iam_role.task_execution.id
+  policy = data.aws_iam_policy_document.task_execution.json
+}
+
+resource "aws_ecs_cluster" "app" {
+  name = local.name_prefix
+}
+
+resource "aws_ecs_task_definition" "app" {
+  family                   = local.name_prefix
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = var.task_cpu
+  memory                   = var.task_memory
+  execution_role_arn       = aws_iam_role.task_execution.arn
+  task_role_arn            = aws_iam_role.task.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "app"
+      image     = local.app_image
+      essential = true
+      portMappings = [
+        {
+          containerPort = 8080
+          hostPort      = 8080
+          protocol      = "tcp"
+        }
+      ]
+      environment = [
+        { name = "PORT", value = "8080" },
+        { name = "STORAGE_BACKEND", value = "postgres" },
+        { name = "DATABASE_URL", value = var.database_url },
+        { name = "AUTH_MODE", value = "dev" },
+        { name = "DEV_SUBJECT", value = "dev|local" },
+        { name = "DEV_ISSUER", value = "dev" },
+        { name = "TRUST_PROXY_HEADERS", value = "true" },
+      ]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.app.name
+          awslogs-region        = var.aws_region
+          awslogs-stream-prefix = "ecs"
+        }
+      }
+    }
+  ])
+}
+
+resource "aws_ecs_task_definition" "migrations" {
+  family                   = "${local.name_prefix}-migrations"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = var.migrations_task_cpu
+  memory                   = var.migrations_task_memory
+  execution_role_arn       = aws_iam_role.task_execution.arn
+  task_role_arn            = aws_iam_role.task.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "migrations"
+      image     = local.migrations_image
+      essential = true
+      environment = [
+        { name = "DATABASE_URL", value = var.database_url },
+      ]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.migrations.name
+          awslogs-region        = var.aws_region
+          awslogs-stream-prefix = "ecs"
+        }
+      }
+    }
+  ])
+}
+
+resource "aws_ecs_service" "app" {
+  name            = local.name_prefix
+  cluster         = aws_ecs_cluster.app.id
+  task_definition = aws_ecs_task_definition.app.arn
+  desired_count   = var.desired_count
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = aws_subnet.private[*].id
+    security_groups  = [aws_security_group.ecs.id]
+    assign_public_ip = true
+  }
+}

--- a/infra/local/outputs.tf
+++ b/infra/local/outputs.tf
@@ -1,0 +1,24 @@
+output "ecs_cluster_name" {
+  description = "ECS cluster name."
+  value       = aws_ecs_cluster.app.name
+}
+
+output "ecs_service_name" {
+  description = "ECS service name."
+  value       = aws_ecs_service.app.name
+}
+
+output "migrations_task_definition_arn" {
+  description = "Migrations task definition ARN."
+  value       = aws_ecs_task_definition.migrations.arn
+}
+
+output "private_subnet_ids_csv" {
+  description = "CSV list of private subnet IDs."
+  value       = join(",", aws_subnet.private[*].id)
+}
+
+output "ecs_task_security_group_id" {
+  description = "Security group ID for ECS tasks."
+  value       = aws_security_group.ecs.id
+}

--- a/infra/local/variables.tf
+++ b/infra/local/variables.tf
@@ -1,0 +1,95 @@
+variable "project_name" {
+  type        = string
+  description = "Project identifier."
+  default     = "trip-planner-api"
+}
+
+variable "aws_region" {
+  type        = string
+  description = "AWS region used by LocalStack."
+  default     = "us-east-1"
+}
+
+variable "localstack_endpoint" {
+  type        = string
+  description = "LocalStack endpoint URL."
+  default     = "http://localhost:4566"
+}
+
+variable "vpc_cidr" {
+  type        = string
+  description = "CIDR block for the VPC."
+  default     = "10.2.0.0/16"
+}
+
+variable "az_count" {
+  type        = number
+  description = "Number of availability zones to use."
+  default     = 2
+}
+
+variable "image_tag" {
+  type        = string
+  description = "Container image tag to deploy."
+  default     = "local"
+}
+
+variable "migrations_image_tag" {
+  type        = string
+  description = "Migrations image tag (defaults to image_tag)."
+  default     = "local-migrations"
+}
+
+variable "image_registry" {
+  type        = string
+  description = "Image registry host used by LocalStack."
+  default     = "localhost:4566"
+}
+
+variable "ecr_repository_name" {
+  type        = string
+  description = "ECR repository name (defaults to <project>-local)."
+  default     = ""
+}
+
+variable "database_url" {
+  type        = string
+  description = "Database URL for local ECS tasks."
+  default     = "postgres://eb:eb@host.docker.internal:5432/eastbay?sslmode=disable"
+}
+
+variable "task_cpu" {
+  type        = string
+  description = "Fargate task CPU units."
+  default     = "256"
+}
+
+variable "task_memory" {
+  type        = string
+  description = "Fargate task memory (MiB)."
+  default     = "512"
+}
+
+variable "migrations_task_cpu" {
+  type        = string
+  description = "Fargate task CPU units for migrations."
+  default     = "256"
+}
+
+variable "migrations_task_memory" {
+  type        = string
+  description = "Fargate task memory (MiB) for migrations."
+  default     = "512"
+}
+
+variable "desired_count" {
+  type        = number
+  description = "Desired ECS task count."
+  default     = 1
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Extra tags to apply."
+  default     = {}
+}

--- a/infra/local/versions.tf
+++ b/infra/local/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/internal/adapters/httpapi/members_handlers_test.go
+++ b/internal/adapters/httpapi/members_handlers_test.go
@@ -2,6 +2,7 @@ package httpapi
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -19,6 +20,7 @@ import (
 	"github.com/Overland-East-Bay/trip-planner-api/internal/platform/auth/jwks_testutil"
 	"github.com/Overland-East-Bay/trip-planner-api/internal/platform/auth/jwtverifier"
 	"github.com/Overland-East-Bay/trip-planner-api/internal/platform/config"
+	portmemberrepo "github.com/Overland-East-Bay/trip-planner-api/internal/ports/out/memberrepo"
 )
 
 type fixedClockMembers struct{ t time.Time }
@@ -236,5 +238,111 @@ func TestMembers_DeleteMe_200_ThenGetMe_404(t *testing.T) {
 	h.ServeHTTP(rec2, req2)
 	if rec2.Code != http.StatusNotFound {
 		t.Fatalf("get status=%d body=%s", rec2.Code, rec2.Body.String())
+	}
+}
+
+func TestMembers_ListAndSearchMembers_ProvisioningAndIncludeInactive(t *testing.T) {
+	t.Parallel()
+
+	h, mint, _, memberRepo := newTestTripRouter(t)
+	authz := "Bearer " + mint(time.Unix(1700000000, 0), "kid-1", "sub-1")
+
+	// Must be provisioned to access the directory.
+	req0 := httptest.NewRequest(http.MethodGet, "/members", nil)
+	req0.Header.Set("Authorization", authz)
+	rec0 := httptest.NewRecorder()
+	h.ServeHTTP(rec0, req0)
+	if rec0.Code != http.StatusUnauthorized {
+		t.Fatalf("status=%d body=%s", rec0.Code, rec0.Body.String())
+	}
+
+	_ = provisionCaller(t, h, authz, "alice1@example.com")
+
+	// Add another inactive member directly.
+	now := time.Unix(200, 0).UTC()
+	_ = memberRepo.Create(context.Background(), portmemberrepo.Member{
+		ID:          "m2",
+		Subject:     "sub-2",
+		DisplayName: "Bob",
+		Email:       "bob@example.com",
+		IsActive:    false,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	})
+
+	req1 := httptest.NewRequest(http.MethodGet, "/members", nil)
+	req1.Header.Set("Authorization", authz)
+	rec1 := httptest.NewRecorder()
+	h.ServeHTTP(rec1, req1)
+	if rec1.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec1.Code, rec1.Body.String())
+	}
+	var list1 struct {
+		Members []oas.MemberDirectoryEntry `json:"members"`
+	}
+	if err := json.Unmarshal(rec1.Body.Bytes(), &list1); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(list1.Members) != 1 {
+		t.Fatalf("len=%d want=1", len(list1.Members))
+	}
+
+	req2 := httptest.NewRequest(http.MethodGet, "/members?includeInactive=true", nil)
+	req2.Header.Set("Authorization", authz)
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec2.Code, rec2.Body.String())
+	}
+	var list2 struct {
+		Members []oas.MemberDirectoryEntry `json:"members"`
+	}
+	if err := json.Unmarshal(rec2.Body.Bytes(), &list2); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(list2.Members) != 2 {
+		t.Fatalf("len=%d want=2", len(list2.Members))
+	}
+
+	// Search should validate min length (422), then succeed.
+	reqBad := httptest.NewRequest(http.MethodGet, "/members/search?q=ab", nil)
+	reqBad.Header.Set("Authorization", authz)
+	recBad := httptest.NewRecorder()
+	h.ServeHTTP(recBad, reqBad)
+	if recBad.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status=%d body=%s", recBad.Code, recBad.Body.String())
+	}
+
+	// Add an active member that matches.
+	_ = memberRepo.Create(context.Background(), portmemberrepo.Member{
+		ID:          "m3",
+		Subject:     "sub-3",
+		DisplayName: "Alice Smith",
+		Email:       "alice2@example.com",
+		IsActive:    true,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	})
+	reqOK := httptest.NewRequest(http.MethodGet, "/members/search?q=ali", nil)
+	reqOK.Header.Set("Authorization", authz)
+	recOK := httptest.NewRecorder()
+	h.ServeHTTP(recOK, reqOK)
+	if recOK.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", recOK.Code, recOK.Body.String())
+	}
+	var search struct {
+		Members []oas.MemberDirectoryEntry `json:"members"`
+	}
+	if err := json.Unmarshal(recOK.Body.Bytes(), &search); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	found := false
+	for _, m := range search.Members {
+		if m.MemberId == "m3" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected to find m3 in results, members=%v", search.Members)
 	}
 }

--- a/internal/adapters/httpapi/members_handlers_test.go
+++ b/internal/adapters/httpapi/members_handlers_test.go
@@ -346,3 +346,55 @@ func TestMembers_ListAndSearchMembers_ProvisioningAndIncludeInactive(t *testing.
 		t.Fatalf("expected to find m3 in results, members=%v", search.Members)
 	}
 }
+
+func TestMembers_VehicleProfile_CreateGetAndPatch(t *testing.T) {
+	t.Parallel()
+
+	h, mint := newTestMemberRouter(t)
+	authz := "Bearer " + mint(time.Unix(1700000000, 0), "kid-1")
+
+	// Create with vehicleProfile.
+	createBody := `{
+		"displayName":"Alice",
+		"email":"alice@example.com",
+		"vehicleProfile":{"make":"Toyota","model":"4Runner","notes":"hello"}
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/members", bytes.NewBufferString(createBody))
+	req.Header.Set("Authorization", authz)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create status=%d body=%s", rec.Code, rec.Body.String())
+	}
+
+	// Get should include the vehicle profile.
+	reqGet := httptest.NewRequest(http.MethodGet, "/members/me", nil)
+	reqGet.Header.Set("Authorization", authz)
+	recGet := httptest.NewRecorder()
+	h.ServeHTTP(recGet, reqGet)
+	if recGet.Code != http.StatusOK {
+		t.Fatalf("get status=%d body=%s", recGet.Code, recGet.Body.String())
+	}
+	var got struct {
+		Member oas.MemberProfile `json:"member"`
+	}
+	if err := json.Unmarshal(recGet.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode get: %v", err)
+	}
+	if got.Member.VehicleProfile == nil {
+		t.Fatalf("expected vehicleProfile present")
+	}
+
+	// Patch vehicle profile fields (null + value).
+	patchBody := `{"vehicleProfile":{"make":null,"model":"Tacoma"}}`
+	reqPatch := httptest.NewRequest(http.MethodPatch, "/members/me", bytes.NewBufferString(patchBody))
+	reqPatch.Header.Set("Authorization", authz)
+	reqPatch.Header.Set("Content-Type", "application/json")
+	reqPatch.Header.Set("Idempotency-Key", "idem-vp-1")
+	recPatch := httptest.NewRecorder()
+	h.ServeHTTP(recPatch, reqPatch)
+	if recPatch.Code != http.StatusOK {
+		t.Fatalf("patch status=%d body=%s", recPatch.Code, recPatch.Body.String())
+	}
+}

--- a/internal/adapters/httpapi/router_test.go
+++ b/internal/adapters/httpapi/router_test.go
@@ -1,0 +1,76 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Overland-East-Bay/trip-planner-api/internal/adapters/httpapi/oas"
+)
+
+func TestNewRouter_Healthz_NoAuthRequired(t *testing.T) {
+	t.Parallel()
+
+	h := NewRouter(StrictUnimplemented{})
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if rec.Body.String() != "ok" {
+		t.Fatalf("body=%q", rec.Body.String())
+	}
+}
+
+func TestNewDevAuthMiddleware_SubjectResolutionAndErrors(t *testing.T) {
+	t.Parallel()
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sub, ok := SubjectFromContext(r.Context())
+		if !ok {
+			t.Fatalf("missing subject in context")
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(sub))
+	})
+
+	t.Run("header wins", func(t *testing.T) {
+		h := NewDevAuthMiddleware("default")(next)
+		req := httptest.NewRequest(http.MethodGet, "/members/me", nil)
+		req.Header.Set("X-Debug-Subject", "  sub-1  ")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK || rec.Body.String() != "sub-1" {
+			t.Fatalf("status=%d body=%q", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("falls back to default", func(t *testing.T) {
+		h := NewDevAuthMiddleware("  sub-default ")(next)
+		req := httptest.NewRequest(http.MethodGet, "/members/me", nil)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK || rec.Body.String() != "sub-default" {
+			t.Fatalf("status=%d body=%q", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("missing subject returns 401", func(t *testing.T) {
+		h := NewDevAuthMiddleware("")(next)
+		req := httptest.NewRequest(http.MethodGet, "/members/me", nil)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+		}
+		var er oas.ErrorResponse
+		_ = json.NewDecoder(rec.Body).Decode(&er)
+		if er.Error.Code != "UNAUTHORIZED" {
+			t.Fatalf("code=%q", er.Error.Code)
+		}
+	})
+}

--- a/internal/adapters/httpapi/server_unit_test.go
+++ b/internal/adapters/httpapi/server_unit_test.go
@@ -1,0 +1,120 @@
+package httpapi
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/oapi-codegen/nullable"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	"github.com/Overland-East-Bay/trip-planner-api/internal/adapters/httpapi/oas"
+	memclock "github.com/Overland-East-Bay/trip-planner-api/internal/adapters/memory/clock"
+	memidempotency "github.com/Overland-East-Bay/trip-planner-api/internal/adapters/memory/idempotency"
+	memmemberrepo "github.com/Overland-East-Bay/trip-planner-api/internal/adapters/memory/memberrepo"
+	memrsvprepo "github.com/Overland-East-Bay/trip-planner-api/internal/adapters/memory/rsvprepo"
+	memtriprepo "github.com/Overland-East-Bay/trip-planner-api/internal/adapters/memory/triprepo"
+	"github.com/Overland-East-Bay/trip-planner-api/internal/app/members"
+	"github.com/Overland-East-Bay/trip-planner-api/internal/app/trips"
+	"github.com/Overland-East-Bay/trip-planner-api/internal/domain"
+)
+
+func TestServer_CreateMyMember_MissingSubjectAndBodyValidation(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	clk := memclock.NewManualClock(time.Unix(1, 0).UTC())
+	memberRepo := memmemberrepo.NewRepo()
+	tripRepo := memtriprepo.NewRepo()
+	rsvpRepo := memrsvprepo.NewRepo()
+	idem := memidempotency.NewStore()
+	s := NewServer(members.NewService(memberRepo, clk), trips.NewService(tripRepo, memberRepo, rsvpRepo), idem)
+
+	// Missing subject -> 401.
+	body := oas.CreateMyMemberJSONRequestBody(oas.CreateMemberRequest{
+		DisplayName: "Alice",
+		Email:       openapi_types.Email("alice@example.com"),
+	})
+	resp, err := s.CreateMyMember(ctx, oas.CreateMyMemberRequestObject{Body: &body})
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if _, ok := resp.(oas.CreateMyMember401JSONResponse); !ok {
+		t.Fatalf("resp=%T want 401", resp)
+	}
+
+	// Missing body -> 422.
+	ctx2 := WithSubject(ctx, "sub-1")
+	resp, err = s.CreateMyMember(ctx2, oas.CreateMyMemberRequestObject{Body: nil})
+	if err != nil {
+		t.Fatalf("err2=%v", err)
+	}
+	if _, ok := resp.(oas.CreateMyMember422JSONResponse); !ok {
+		t.Fatalf("resp2=%T want 422", resp)
+	}
+
+	// Invalid email -> 422.
+	bodyBad := oas.CreateMyMemberJSONRequestBody(oas.CreateMemberRequest{
+		DisplayName: "Alice",
+		Email:       openapi_types.Email("not-an-email"),
+	})
+	resp, err = s.CreateMyMember(ctx2, oas.CreateMyMemberRequestObject{Body: &bodyBad})
+	if err != nil {
+		t.Fatalf("err3=%v", err)
+	}
+	if _, ok := resp.(oas.CreateMyMember422JSONResponse); !ok {
+		t.Fatalf("resp3=%T want 422", resp)
+	}
+}
+
+func TestVehicleProfileMapping_FromDomainAndFromOAS(t *testing.T) {
+	t.Parallel()
+
+	make := "Toyota"
+	model := "4Runner"
+	vp := domain.VehicleProfile{
+		Make:  &make,
+		Model: &model,
+	}
+
+	out := vehicleProfileFromDomain(vp)
+	if out == nil {
+		t.Fatalf("expected non-nil")
+	}
+	if !out.Make.IsSpecified() || out.Make.IsNull() {
+		t.Fatalf("make not specified")
+	}
+	if got, _ := out.Make.Get(); got != "Toyota" {
+		t.Fatalf("make=%q", got)
+	}
+
+	var o oas.VehicleProfile
+	o.Make = nullable.NewNullableWithValue("Jeep")
+	o.Model = nullable.NewNullableWithValue("Wrangler")
+	patch := vehicleProfilePatchFromOAS(o)
+	if patch == nil || !patch.Make.IsSpecified() || patch.Make.IsNull() || patch.Make.Value() != "Jeep" {
+		t.Fatalf("patch=%+v", patch)
+	}
+}
+
+func TestOptionalFloatFromNullableTrips(t *testing.T) {
+	t.Parallel()
+
+	var u nullable.Nullable[float64]
+	if got := optionalFloatFromNullableTrips(u); got.IsSpecified() || got.IsNull() {
+		t.Fatalf("unspecified=%+v", got)
+	}
+
+	var n nullable.Nullable[float64]
+	n.SetNull()
+	if got := optionalFloatFromNullableTrips(n); !got.IsSpecified() || !got.IsNull() {
+		t.Fatalf("null=%+v", got)
+	}
+
+	var v nullable.Nullable[float64]
+	v.Set(1.23)
+	got := optionalFloatFromNullableTrips(v)
+	if !got.IsSpecified() || got.IsNull() || got.Value() != 1.23 {
+		t.Fatalf("value=%+v", got)
+	}
+}

--- a/internal/adapters/httpapi/strict_unimplemented_test.go
+++ b/internal/adapters/httpapi/strict_unimplemented_test.go
@@ -1,0 +1,42 @@
+package httpapi
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Overland-East-Bay/trip-planner-api/internal/adapters/httpapi/oas"
+)
+
+func TestStrictUnimplemented_ReturnsOpenAPI500WithNotImplementedError(t *testing.T) {
+	t.Parallel()
+
+	s := StrictUnimplemented{}
+	ctx := context.Background()
+
+	resp, err := s.ListMembers(ctx, oas.ListMembersRequestObject{})
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	w := httptest.NewRecorder()
+	if err := resp.VisitListMembersResponse(w); err != nil {
+		t.Fatalf("visit: %v", err)
+	}
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status=%d", w.Code)
+	}
+
+	// Spot-check one more endpoint to ensure wiring is consistent.
+	resp2, err := s.GetTripDetails(ctx, oas.GetTripDetailsRequestObject{TripId: "t1"})
+	if err != nil {
+		t.Fatalf("err2=%v", err)
+	}
+	w2 := httptest.NewRecorder()
+	if err := resp2.VisitGetTripDetailsResponse(w2); err != nil {
+		t.Fatalf("visit2: %v", err)
+	}
+	if w2.Code != http.StatusInternalServerError {
+		t.Fatalf("status2=%d", w2.Code)
+	}
+}

--- a/internal/adapters/httpapi/strict_unimplemented_test.go
+++ b/internal/adapters/httpapi/strict_unimplemented_test.go
@@ -27,16 +27,28 @@ func TestStrictUnimplemented_ReturnsOpenAPI500WithNotImplementedError(t *testing
 		t.Fatalf("status=%d", w.Code)
 	}
 
-	// Spot-check one more endpoint to ensure wiring is consistent.
-	resp2, err := s.GetTripDetails(ctx, oas.GetTripDetailsRequestObject{TripId: "t1"})
+	// Spot-check a few more endpoints to ensure wiring is consistent.
+	resp2, err := s.CreateMyMember(ctx, oas.CreateMyMemberRequestObject{})
 	if err != nil {
 		t.Fatalf("err2=%v", err)
 	}
 	w2 := httptest.NewRecorder()
-	if err := resp2.VisitGetTripDetailsResponse(w2); err != nil {
+	if err := resp2.VisitCreateMyMemberResponse(w2); err != nil {
 		t.Fatalf("visit2: %v", err)
 	}
 	if w2.Code != http.StatusInternalServerError {
 		t.Fatalf("status2=%d", w2.Code)
+	}
+
+	resp3, err := s.PublishTrip(ctx, oas.PublishTripRequestObject{TripId: "t1"})
+	if err != nil {
+		t.Fatalf("err3=%v", err)
+	}
+	w3 := httptest.NewRecorder()
+	if err := resp3.VisitPublishTripResponse(w3); err != nil {
+		t.Fatalf("visit3: %v", err)
+	}
+	if w3.Code != http.StatusInternalServerError {
+		t.Fatalf("status3=%d", w3.Code)
 	}
 }

--- a/internal/adapters/httpapi/trips_handlers_test.go
+++ b/internal/adapters/httpapi/trips_handlers_test.go
@@ -747,3 +747,66 @@ func TestTrips_PublishAndCancel_HappyPathAndCancelIdempotency(t *testing.T) {
 		t.Fatalf("cancel2 status=%d body=%s", recCancel2.Code, recCancel2.Body.String())
 	}
 }
+
+func TestTrips_PublishTrip_ErrorCases_PrivateDraftMissingFieldsAndNotOrganizer(t *testing.T) {
+	t.Parallel()
+
+	h, mint, _, _ := newTestTripRouter(t)
+	authz1 := "Bearer " + mint(time.Unix(1700000000, 0), "kid-1", "sub-1")
+	authz2 := "Bearer " + mint(time.Unix(1700000000, 0), "kid-1", "sub-2")
+	_ = provisionCaller(t, h, authz1, "alice1@example.com")
+	_ = provisionCaller(t, h, authz2, "bob2@example.com")
+
+	// Create a private draft (default) as member1.
+	reqCreate := httptest.NewRequest(http.MethodPost, "/trips", bytes.NewBufferString(`{"name":"Trip"}`))
+	reqCreate.Header.Set("Authorization", authz1)
+	reqCreate.Header.Set("Content-Type", "application/json")
+	reqCreate.Header.Set("Idempotency-Key", "k-create3")
+	recCreate := httptest.NewRecorder()
+	h.ServeHTTP(recCreate, reqCreate)
+	if recCreate.Code != http.StatusCreated {
+		t.Fatalf("create status=%d body=%s", recCreate.Code, recCreate.Body.String())
+	}
+	var created struct {
+		Trip oas.TripCreated `json:"trip"`
+	}
+	_ = json.Unmarshal(recCreate.Body.Bytes(), &created)
+	tripID := created.Trip.TripId
+
+	// Private drafts cannot be published.
+	reqPub1 := httptest.NewRequest(http.MethodPost, "/trips/"+tripID+"/publish", nil)
+	reqPub1.Header.Set("Authorization", authz1)
+	recPub1 := httptest.NewRecorder()
+	h.ServeHTTP(recPub1, reqPub1)
+	if recPub1.Code != http.StatusConflict {
+		t.Fatalf("publish private status=%d body=%s", recPub1.Code, recPub1.Body.String())
+	}
+
+	// Make public but still missing required publish fields => 409.
+	reqVis := httptest.NewRequest(http.MethodPut, "/trips/"+tripID+"/draft-visibility", bytes.NewBufferString(`{"draftVisibility":"PUBLIC"}`))
+	reqVis.Header.Set("Authorization", authz1)
+	reqVis.Header.Set("Content-Type", "application/json")
+	reqVis.Header.Set("Idempotency-Key", "k-vis3")
+	recVis := httptest.NewRecorder()
+	h.ServeHTTP(recVis, reqVis)
+	if recVis.Code != http.StatusOK {
+		t.Fatalf("vis status=%d body=%s", recVis.Code, recVis.Body.String())
+	}
+
+	reqPub2 := httptest.NewRequest(http.MethodPost, "/trips/"+tripID+"/publish", nil)
+	reqPub2.Header.Set("Authorization", authz1)
+	recPub2 := httptest.NewRecorder()
+	h.ServeHTTP(recPub2, reqPub2)
+	if recPub2.Code != http.StatusConflict {
+		t.Fatalf("publish missing fields status=%d body=%s", recPub2.Code, recPub2.Body.String())
+	}
+
+	// Not organizer should see 404 even if draft is public.
+	reqPub3 := httptest.NewRequest(http.MethodPost, "/trips/"+tripID+"/publish", nil)
+	reqPub3.Header.Set("Authorization", authz2)
+	recPub3 := httptest.NewRecorder()
+	h.ServeHTTP(recPub3, reqPub3)
+	if recPub3.Code != http.StatusNotFound {
+		t.Fatalf("publish not organizer status=%d body=%s", recPub3.Code, recPub3.Body.String())
+	}
+}

--- a/internal/adapters/httpapi/trips_handlers_test.go
+++ b/internal/adapters/httpapi/trips_handlers_test.go
@@ -619,7 +619,7 @@ func TestTrips_UpdateTrip_IdempotencyReplayAndConflict(t *testing.T) {
 	}
 
 	// Update with idempotency key.
-	body1 := `{"description":"Desc","capacityRigs":2,"meetingLocation":{"label":"Meet","address":"123 Main","latitude":37.0,"longitude":-122.0}}`
+	body1 := `{"description":"Desc","capacityRigs":2,"artifactIds":[],"meetingLocation":{"label":"Meet","address":"123 Main","latitudeLongitude":{"latitude":37.0,"longitude":-122.0}}}`
 	req1 := httptest.NewRequest(http.MethodPatch, "/trips/"+tripID, bytes.NewBufferString(body1))
 	req1.Header.Set("Authorization", authz)
 	req1.Header.Set("Content-Type", "application/json")
@@ -631,7 +631,7 @@ func TestTrips_UpdateTrip_IdempotencyReplayAndConflict(t *testing.T) {
 	}
 
 	// Replay: same key + semantically same payload should return 200.
-	body2 := `{"description":"Desc","capacityRigs":2,"meetingLocation":{"label":"Meet","address":"123 Main","latitude":37.0,"longitude":-122.0}}`
+	body2 := `{"description":"Desc","capacityRigs":2,"artifactIds":[],"meetingLocation":{"label":"Meet","address":"123 Main","latitudeLongitude":{"latitude":37.0,"longitude":-122.0}}}`
 	req2 := httptest.NewRequest(http.MethodPatch, "/trips/"+tripID, bytes.NewBufferString(body2))
 	req2.Header.Set("Authorization", authz)
 	req2.Header.Set("Content-Type", "application/json")

--- a/internal/adapters/httpapi/trips_handlers_test.go
+++ b/internal/adapters/httpapi/trips_handlers_test.go
@@ -591,3 +591,159 @@ func TestTrips_RSVP_Flow_SetGetSummary_IdempotencyAndCapacity(t *testing.T) {
 		t.Fatalf("expected rsvpSummary and myRsvp in trip details for m1")
 	}
 }
+
+func TestTrips_UpdateTrip_IdempotencyReplayAndConflict(t *testing.T) {
+	t.Parallel()
+
+	h, mint, _, _ := newTestTripRouter(t)
+	authz := "Bearer " + mint(time.Unix(1700000000, 0), "kid-1", "sub-1")
+	_ = provisionCaller(t, h, authz, "alice1@example.com")
+
+	// Create draft.
+	reqCreate := httptest.NewRequest(http.MethodPost, "/trips", bytes.NewBufferString(`{"name":"Trip"}`))
+	reqCreate.Header.Set("Authorization", authz)
+	reqCreate.Header.Set("Content-Type", "application/json")
+	reqCreate.Header.Set("Idempotency-Key", "k-create")
+	recCreate := httptest.NewRecorder()
+	h.ServeHTTP(recCreate, reqCreate)
+	if recCreate.Code != http.StatusCreated {
+		t.Fatalf("create status=%d body=%s", recCreate.Code, recCreate.Body.String())
+	}
+	var created struct {
+		Trip oas.TripCreated `json:"trip"`
+	}
+	_ = json.Unmarshal(recCreate.Body.Bytes(), &created)
+	tripID := created.Trip.TripId
+	if tripID == "" {
+		t.Fatalf("missing tripId")
+	}
+
+	// Update with idempotency key.
+	body1 := `{"description":"Desc","capacityRigs":2,"meetingLocation":{"label":"Meet","address":"123 Main","latitude":37.0,"longitude":-122.0}}`
+	req1 := httptest.NewRequest(http.MethodPatch, "/trips/"+tripID, bytes.NewBufferString(body1))
+	req1.Header.Set("Authorization", authz)
+	req1.Header.Set("Content-Type", "application/json")
+	req1.Header.Set("Idempotency-Key", "k-upd")
+	rec1 := httptest.NewRecorder()
+	h.ServeHTTP(rec1, req1)
+	if rec1.Code != http.StatusOK {
+		t.Fatalf("patch status=%d body=%s", rec1.Code, rec1.Body.String())
+	}
+
+	// Replay: same key + semantically same payload should return 200.
+	body2 := `{"description":"Desc","capacityRigs":2,"meetingLocation":{"label":"Meet","address":"123 Main","latitude":37.0,"longitude":-122.0}}`
+	req2 := httptest.NewRequest(http.MethodPatch, "/trips/"+tripID, bytes.NewBufferString(body2))
+	req2.Header.Set("Authorization", authz)
+	req2.Header.Set("Content-Type", "application/json")
+	req2.Header.Set("Idempotency-Key", "k-upd")
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("patch2 status=%d body=%s", rec2.Code, rec2.Body.String())
+	}
+
+	// Conflict: same key + different payload should 409.
+	body3 := `{"description":"Different"}`
+	req3 := httptest.NewRequest(http.MethodPatch, "/trips/"+tripID, bytes.NewBufferString(body3))
+	req3.Header.Set("Authorization", authz)
+	req3.Header.Set("Content-Type", "application/json")
+	req3.Header.Set("Idempotency-Key", "k-upd")
+	rec3 := httptest.NewRecorder()
+	h.ServeHTTP(rec3, req3)
+	if rec3.Code != http.StatusConflict {
+		t.Fatalf("patch3 status=%d body=%s", rec3.Code, rec3.Body.String())
+	}
+}
+
+func TestTrips_PublishAndCancel_HappyPathAndCancelIdempotency(t *testing.T) {
+	t.Parallel()
+
+	h, mint, _, _ := newTestTripRouter(t)
+	authz := "Bearer " + mint(time.Unix(1700000000, 0), "kid-1", "sub-1")
+	_ = provisionCaller(t, h, authz, "alice1@example.com")
+
+	// Create draft.
+	reqCreate := httptest.NewRequest(http.MethodPost, "/trips", bytes.NewBufferString(`{"name":"Snow Run"}`))
+	reqCreate.Header.Set("Authorization", authz)
+	reqCreate.Header.Set("Content-Type", "application/json")
+	reqCreate.Header.Set("Idempotency-Key", "k-create2")
+	recCreate := httptest.NewRecorder()
+	h.ServeHTTP(recCreate, reqCreate)
+	if recCreate.Code != http.StatusCreated {
+		t.Fatalf("create status=%d body=%s", recCreate.Code, recCreate.Body.String())
+	}
+	var created struct {
+		Trip oas.TripCreated `json:"trip"`
+	}
+	_ = json.Unmarshal(recCreate.Body.Bytes(), &created)
+	tripID := created.Trip.TripId
+
+	// Make public.
+	reqVis := httptest.NewRequest(http.MethodPut, "/trips/"+tripID+"/draft-visibility", bytes.NewBufferString(`{"draftVisibility":"PUBLIC"}`))
+	reqVis.Header.Set("Authorization", authz)
+	reqVis.Header.Set("Content-Type", "application/json")
+	reqVis.Header.Set("Idempotency-Key", "k-vis2")
+	recVis := httptest.NewRecorder()
+	h.ServeHTTP(recVis, reqVis)
+	if recVis.Code != http.StatusOK {
+		t.Fatalf("vis status=%d body=%s", recVis.Code, recVis.Body.String())
+	}
+
+	// Fill required publish fields.
+	reqUpd := httptest.NewRequest(http.MethodPatch, "/trips/"+tripID, bytes.NewBufferString(`{
+		"description":"Fun trip",
+		"startDate":"2026-04-01",
+		"endDate":"2026-04-02",
+		"capacityRigs":5,
+		"difficultyText":"Easy",
+		"commsRequirementsText":"FRS",
+		"recommendedRequirementsText":"Spare tire",
+		"meetingLocation":{"label":"Meet","address":"Trailhead"}
+	}`))
+	reqUpd.Header.Set("Authorization", authz)
+	reqUpd.Header.Set("Content-Type", "application/json")
+	reqUpd.Header.Set("Idempotency-Key", "k-upd2")
+	recUpd := httptest.NewRecorder()
+	h.ServeHTTP(recUpd, reqUpd)
+	if recUpd.Code != http.StatusOK {
+		t.Fatalf("upd status=%d body=%s", recUpd.Code, recUpd.Body.String())
+	}
+
+	// Publish.
+	reqPub := httptest.NewRequest(http.MethodPost, "/trips/"+tripID+"/publish", nil)
+	reqPub.Header.Set("Authorization", authz)
+	recPub := httptest.NewRecorder()
+	h.ServeHTTP(recPub, reqPub)
+	if recPub.Code != http.StatusOK {
+		t.Fatalf("publish status=%d body=%s", recPub.Code, recPub.Body.String())
+	}
+	var pub struct {
+		Trip             oas.TripDetails `json:"trip"`
+		AnnouncementCopy string          `json:"announcementCopy"`
+	}
+	if err := json.Unmarshal(recPub.Body.Bytes(), &pub); err != nil {
+		t.Fatalf("decode publish: %v", err)
+	}
+	if pub.Trip.Status != "PUBLISHED" || pub.AnnouncementCopy == "" {
+		t.Fatalf("pub=%+v", pub)
+	}
+
+	// Cancel with idempotency key and replay.
+	reqCancel := httptest.NewRequest(http.MethodPost, "/trips/"+tripID+"/cancel", nil)
+	reqCancel.Header.Set("Authorization", authz)
+	reqCancel.Header.Set("Idempotency-Key", "k-cancel")
+	recCancel := httptest.NewRecorder()
+	h.ServeHTTP(recCancel, reqCancel)
+	if recCancel.Code != http.StatusOK {
+		t.Fatalf("cancel status=%d body=%s", recCancel.Code, recCancel.Body.String())
+	}
+
+	reqCancel2 := httptest.NewRequest(http.MethodPost, "/trips/"+tripID+"/cancel", nil)
+	reqCancel2.Header.Set("Authorization", authz)
+	reqCancel2.Header.Set("Idempotency-Key", "k-cancel")
+	recCancel2 := httptest.NewRecorder()
+	h.ServeHTTP(recCancel2, reqCancel2)
+	if recCancel2.Code != http.StatusOK {
+		t.Fatalf("cancel2 status=%d body=%s", recCancel2.Code, recCancel2.Body.String())
+	}
+}

--- a/internal/adapters/memory/memberrepo/repo_test.go
+++ b/internal/adapters/memory/memberrepo/repo_test.go
@@ -185,3 +185,58 @@ func TestRepo_SearchActiveByDisplayName_RespectsLimit(t *testing.T) {
 		t.Fatalf("len=%d, want 1", len(got))
 	}
 }
+
+func TestRepo_ClonesPointerFieldsOnRead(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	r := NewRepo()
+	now := time.Unix(200, 0).UTC()
+
+	gae := "alias@example.com"
+	make := "Toyota"
+	model := "4Runner"
+	m := memberrepo.Member{
+		ID:              "m1",
+		Subject:         "sub-1",
+		DisplayName:     "Alice",
+		Email:           "alice@example.com",
+		GroupAliasEmail: &gae,
+		VehicleProfile: &domain.VehicleProfile{
+			Make:  &make,
+			Model: &model,
+		},
+		IsActive:  true,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := r.Create(ctx, m); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := r.GetByID(ctx, "m1")
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if got.GroupAliasEmail == nil || *got.GroupAliasEmail != "alias@example.com" {
+		t.Fatalf("GroupAliasEmail=%v", got.GroupAliasEmail)
+	}
+	if got.VehicleProfile == nil || got.VehicleProfile.Make == nil || *got.VehicleProfile.Make != "Toyota" {
+		t.Fatalf("VehicleProfile=%+v", got.VehicleProfile)
+	}
+
+	// Mutate the returned struct pointers; repository storage should be unaffected.
+	*got.GroupAliasEmail = "changed@example.com"
+	*got.VehicleProfile.Make = "Changed"
+
+	got2, err := r.GetBySubject(ctx, "sub-1")
+	if err != nil {
+		t.Fatalf("GetBySubject: %v", err)
+	}
+	if got2.GroupAliasEmail == nil || *got2.GroupAliasEmail != "alias@example.com" {
+		t.Fatalf("expected clone on read (groupAliasEmail), got=%v", got2.GroupAliasEmail)
+	}
+	if got2.VehicleProfile == nil || got2.VehicleProfile.Make == nil || *got2.VehicleProfile.Make != "Toyota" {
+		t.Fatalf("expected clone on read (vehicleProfile), got=%+v", got2.VehicleProfile)
+	}
+}

--- a/internal/adapters/memory/rsvprepo/repo_test.go
+++ b/internal/adapters/memory/rsvprepo/repo_test.go
@@ -58,3 +58,57 @@ func TestRepo_GetUpsertCountYesList(t *testing.T) {
 		t.Fatalf("ListByTrip() order=%v, want [m1 m2]", []domain.MemberID{list[0].MemberID, list[1].MemberID})
 	}
 }
+
+func TestRepo_ListByMember_OrdersByTripIDThenUpdatedAt(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	r := NewRepo()
+
+	t1 := time.Unix(10, 0).UTC()
+	t2 := time.Unix(20, 0).UTC()
+	t3 := time.Unix(30, 0).UTC()
+
+	_ = r.Upsert(ctx, rsvprepo.RSVP{TripID: "t2", MemberID: "m1", Status: rsvprepo.StatusNo, UpdatedAt: t2})
+	_ = r.Upsert(ctx, rsvprepo.RSVP{TripID: "t1", MemberID: "m1", Status: rsvprepo.StatusYes, UpdatedAt: t3})
+	_ = r.Upsert(ctx, rsvprepo.RSVP{TripID: "t1", MemberID: "m1", Status: rsvprepo.StatusNo, UpdatedAt: t1}) // overwrite same key; updatedAt changes ordering
+	_ = r.Upsert(ctx, rsvprepo.RSVP{TripID: "t1", MemberID: "m2", Status: rsvprepo.StatusYes, UpdatedAt: t1})
+
+	list, err := r.ListByMember(ctx, "m1")
+	if err != nil {
+		t.Fatalf("ListByMember: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("len=%d want=2", len(list))
+	}
+	// TripID order first: t1 then t2.
+	if list[0].TripID != "t1" || list[1].TripID != "t2" {
+		t.Fatalf("order=%v", []domain.TripID{list[0].TripID, list[1].TripID})
+	}
+}
+
+func TestRepo_DeleteByMember_DeletesAllForMember(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	r := NewRepo()
+
+	_ = r.Upsert(ctx, rsvprepo.RSVP{TripID: "t1", MemberID: "m1", Status: rsvprepo.StatusYes, UpdatedAt: time.Unix(1, 0).UTC()})
+	_ = r.Upsert(ctx, rsvprepo.RSVP{TripID: "t2", MemberID: "m1", Status: rsvprepo.StatusNo, UpdatedAt: time.Unix(2, 0).UTC()})
+	_ = r.Upsert(ctx, rsvprepo.RSVP{TripID: "t1", MemberID: "m2", Status: rsvprepo.StatusYes, UpdatedAt: time.Unix(3, 0).UTC()})
+
+	if err := r.DeleteByMember(ctx, "m1"); err != nil {
+		t.Fatalf("DeleteByMember: %v", err)
+	}
+
+	if _, err := r.Get(ctx, "t1", "m1"); err != rsvprepo.ErrNotFound {
+		t.Fatalf("expected deleted: %v", err)
+	}
+	if _, err := r.Get(ctx, "t2", "m1"); err != rsvprepo.ErrNotFound {
+		t.Fatalf("expected deleted: %v", err)
+	}
+	// Other member remains.
+	if _, err := r.Get(ctx, "t1", "m2"); err != nil {
+		t.Fatalf("expected m2 record present: %v", err)
+	}
+}

--- a/internal/adapters/memory/triprepo/repo_test.go
+++ b/internal/adapters/memory/triprepo/repo_test.go
@@ -93,3 +93,34 @@ func TestRepo_ListDraftsVisibleTo_VisibilityRules(t *testing.T) {
 		t.Fatalf("order=%v, want [t1 t3]", []domain.TripID{got[0].ID, got[1].ID})
 	}
 }
+
+func TestRepo_Save_UpsertsAndRejectsEmptyID(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	r := NewRepo()
+
+	if err := r.Save(ctx, triprepo.Trip{}); err != triprepo.ErrNotFound {
+		t.Fatalf("Save(empty id) err=%v want=%v", err, triprepo.ErrNotFound)
+	}
+
+	name := "Trip"
+	t1 := triprepo.Trip{ID: "t1", Status: triprepo.StatusDraft, Name: &name, CreatedAt: time.Unix(1, 0).UTC(), UpdatedAt: time.Unix(1, 0).UTC()}
+	if err := r.Save(ctx, t1); err != nil {
+		t.Fatalf("Save(new) err=%v", err)
+	}
+
+	// Update via Save.
+	name2 := "Trip 2"
+	t1.Name = &name2
+	if err := r.Save(ctx, t1); err != nil {
+		t.Fatalf("Save(update) err=%v", err)
+	}
+	got, err := r.GetByID(ctx, "t1")
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if got.Name == nil || *got.Name != "Trip 2" {
+		t.Fatalf("got.Name=%v", got.Name)
+	}
+}

--- a/internal/adapters/memory/triprepo/repo_test.go
+++ b/internal/adapters/memory/triprepo/repo_test.go
@@ -124,3 +124,57 @@ func TestRepo_Save_UpsertsAndRejectsEmptyID(t *testing.T) {
 		t.Fatalf("got.Name=%v", got.Name)
 	}
 }
+
+func TestRepo_ReadsClonePointersAndLocation(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	r := NewRepo()
+
+	name := "Trip"
+	cap := 5
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	addr := "123 Main"
+	lat := 37.0
+	lng := -122.0
+	loc := &domain.Location{Label: "Meet", Address: &addr, Latitude: &lat, Longitude: &lng}
+
+	tp := triprepo.Trip{
+		ID:              "t1",
+		Status:          triprepo.StatusPublished,
+		Name:            &name,
+		CapacityRigs:    &cap,
+		StartDate:       &start,
+		MeetingLocation: loc,
+		CreatedAt:       time.Unix(1, 0).UTC(),
+		UpdatedAt:       time.Unix(1, 0).UTC(),
+	}
+	if err := r.Create(ctx, tp); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := r.GetByID(ctx, "t1")
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if got.CapacityRigs == nil || *got.CapacityRigs != 5 {
+		t.Fatalf("capacity=%v", got.CapacityRigs)
+	}
+	if got.StartDate == nil || got.StartDate.UTC().Format("2006-01-02") != "2026-01-01" {
+		t.Fatalf("startDate=%v", got.StartDate)
+	}
+	if got.MeetingLocation == nil || got.MeetingLocation.Address == nil || *got.MeetingLocation.Address != "123 Main" {
+		t.Fatalf("location=%+v", got.MeetingLocation)
+	}
+
+	// Mutate returned pointers; stored data should not change.
+	*got.CapacityRigs = 99
+	*got.MeetingLocation.Address = "Changed"
+	got2, _ := r.GetByID(ctx, "t1")
+	if got2.CapacityRigs == nil || *got2.CapacityRigs != 5 {
+		t.Fatalf("expected clone for capacity, got=%v", got2.CapacityRigs)
+	}
+	if got2.MeetingLocation == nil || got2.MeetingLocation.Address == nil || *got2.MeetingLocation.Address != "123 Main" {
+		t.Fatalf("expected clone for location, got=%+v", got2.MeetingLocation)
+	}
+}

--- a/internal/app/members/more_test.go
+++ b/internal/app/members/more_test.go
@@ -154,6 +154,32 @@ func TestService_UpdateMyMemberProfile_EmailUniquenessAndVehicleProfilePatch(t *
 	}
 }
 
+func TestService_SearchMembers_TrimsAndRespectsLimit(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	repo := memmemberrepo.NewRepo()
+	clk := memclock.NewManualClock(time.Unix(100, 0).UTC())
+	svc := NewService(repo, clk)
+	svc.SearchLimit = 1
+
+	now := clk.Now()
+	_ = repo.Create(ctx, portmemberrepo.Member{ID: "m1", Subject: "sub-1", DisplayName: "Alice Smith", Email: "a1@example.com", IsActive: true, CreatedAt: now, UpdatedAt: now})
+	_ = repo.Create(ctx, portmemberrepo.Member{ID: "m2", Subject: "sub-2", DisplayName: "Alice Jones", Email: "a2@example.com", IsActive: true, CreatedAt: now, UpdatedAt: now})
+	_ = repo.Create(ctx, portmemberrepo.Member{ID: "m3", Subject: "sub-3", DisplayName: "Bob", Email: "b@example.com", IsActive: true, CreatedAt: now, UpdatedAt: now})
+
+	got, err := svc.SearchMembers(ctx, "  ali  ")
+	if err != nil {
+		t.Fatalf("SearchMembers: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len=%d want=1", len(got))
+	}
+	if got[0].ID != "m1" && got[0].ID != "m2" {
+		t.Fatalf("unexpected member: %+v", got[0])
+	}
+}
+
 func TestService_AnonymizeAndDeactivateMyMember_ScrubsFields(t *testing.T) {
 	t.Parallel()
 

--- a/internal/app/members/more_test.go
+++ b/internal/app/members/more_test.go
@@ -235,3 +235,132 @@ func TestService_AnonymizeAndDeactivateMyMember_ScrubsFields(t *testing.T) {
 		t.Fatalf("err=%v", err)
 	}
 }
+
+func TestService_UpdateMyMemberProfile_ValidationsAndVehicleProfileNull(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	repo := memmemberrepo.NewRepo()
+	clk := memclock.NewManualClock(time.Unix(100, 0).UTC())
+	svc := NewService(repo, clk)
+
+	// Not provisioned.
+	_, err := svc.UpdateMyMemberProfile(ctx, "sub-missing", UpdateMyMemberProfileInput{DisplayName: Some("X")})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	ae := (*Error)(nil)
+	if !errors.As(err, &ae) || ae.Status != 404 || ae.Code != "MEMBER_NOT_PROVISIONED" {
+		t.Fatalf("err=%v", err)
+	}
+
+	// Seed a member.
+	_, err = svc.CreateMyMember(ctx, "sub-1", CreateMyMemberInput{DisplayName: "Alice", Email: "alice@example.com"})
+	if err != nil {
+		t.Fatalf("CreateMyMember: %v", err)
+	}
+
+	// displayName: null rejected.
+	_, err = svc.UpdateMyMemberProfile(ctx, "sub-1", UpdateMyMemberProfileInput{DisplayName: Null[string]()})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !errors.As(err, &ae) || ae.Status != 422 || ae.Code != "VALIDATION_ERROR" {
+		t.Fatalf("err=%v", err)
+	}
+
+	// displayName: empty after normalization rejected.
+	_, err = svc.UpdateMyMemberProfile(ctx, "sub-1", UpdateMyMemberProfileInput{DisplayName: Some("   ")})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !errors.As(err, &ae) || ae.Status != 422 {
+		t.Fatalf("err=%v", err)
+	}
+
+	// email: null rejected.
+	_, err = svc.UpdateMyMemberProfile(ctx, "sub-1", UpdateMyMemberProfileInput{Email: Null[string]()})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !errors.As(err, &ae) || ae.Status != 422 {
+		t.Fatalf("err=%v", err)
+	}
+
+	// email: must be bare email (no "Name <x@y>").
+	_, err = svc.UpdateMyMemberProfile(ctx, "sub-1", UpdateMyMemberProfileInput{Email: Some("Alice <alice@example.com>")})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !errors.As(err, &ae) || ae.Status != 422 {
+		t.Fatalf("err=%v", err)
+	}
+
+	// groupAliasEmail: invalid rejected.
+	_, err = svc.UpdateMyMemberProfile(ctx, "sub-1", UpdateMyMemberProfileInput{GroupAliasEmail: Some("not-an-email")})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !errors.As(err, &ae) || ae.Status != 422 {
+		t.Fatalf("err=%v", err)
+	}
+
+	// vehicleProfile: null clears.
+	updated, err := svc.UpdateMyMemberProfile(ctx, "sub-1", UpdateMyMemberProfileInput{VehicleProfile: Null[VehicleProfilePatch]()})
+	if err != nil {
+		t.Fatalf("UpdateMyMemberProfile(vehicleProfile=null): %v", err)
+	}
+	if updated.VehicleProfile != nil {
+		t.Fatalf("expected vehicleProfile cleared")
+	}
+}
+
+func TestService_CreateMyMember_Validations(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	repo := memmemberrepo.NewRepo()
+	clk := memclock.NewManualClock(time.Unix(100, 0).UTC())
+	svc := NewService(repo, clk)
+
+	// displayName required.
+	_, err := svc.CreateMyMember(ctx, "sub-1", CreateMyMemberInput{DisplayName: "   ", Email: "a@example.com"})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	ae := (*Error)(nil)
+	if !errors.As(err, &ae) || ae.Status != 422 || ae.Code != "VALIDATION_ERROR" {
+		t.Fatalf("err=%v", err)
+	}
+
+	// email required.
+	_, err = svc.CreateMyMember(ctx, "sub-2", CreateMyMemberInput{DisplayName: "Alice", Email: ""})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !errors.As(err, &ae) || ae.Status != 422 {
+		t.Fatalf("err=%v", err)
+	}
+
+	// email must be bare (covers validateEmail addr.Address != email).
+	_, err = svc.CreateMyMember(ctx, "sub-3", CreateMyMemberInput{DisplayName: "Alice", Email: "Alice <alice@example.com>"})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !errors.As(err, &ae) || ae.Status != 422 {
+		t.Fatalf("err=%v", err)
+	}
+
+	// uniqueness across different subject IDs.
+	_, err = svc.CreateMyMember(ctx, "sub-4", CreateMyMemberInput{DisplayName: "A", Email: "dup@example.com"})
+	if err != nil {
+		t.Fatalf("CreateMyMember: %v", err)
+	}
+	_, err = svc.CreateMyMember(ctx, "sub-5", CreateMyMemberInput{DisplayName: "B", Email: "DUP@example.com"})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !errors.As(err, &ae) || ae.Status != 409 || ae.Code != "EMAIL_ALREADY_IN_USE" {
+		t.Fatalf("err=%v", err)
+	}
+}

--- a/internal/app/members/more_test.go
+++ b/internal/app/members/more_test.go
@@ -1,0 +1,211 @@
+package members
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	memclock "github.com/Overland-East-Bay/trip-planner-api/internal/adapters/memory/clock"
+	memmemberrepo "github.com/Overland-East-Bay/trip-planner-api/internal/adapters/memory/memberrepo"
+	"github.com/Overland-East-Bay/trip-planner-api/internal/domain"
+	portmemberrepo "github.com/Overland-East-Bay/trip-planner-api/internal/ports/out/memberrepo"
+)
+
+func TestError_ErrorStringAndWithDetailsCopies(t *testing.T) {
+	t.Parallel()
+
+	if (*Error)(nil).Error() != "<nil>" {
+		t.Fatalf("nil error string mismatch")
+	}
+
+	e := &Error{Status: 409, Code: "CODE", Message: "msg"}
+	if got := e.Error(); got != "CODE: msg" {
+		t.Fatalf("Error()=%q", got)
+	}
+
+	e2 := &Error{Status: 500, Message: "boom"}
+	if got := e2.Error(); got != "app error (status=500): boom" {
+		t.Fatalf("Error()=%q", got)
+	}
+
+	d := map[string]any{"a": 1}
+	e3 := e.WithDetails(d)
+	if e3 == nil || e3.Details["a"] != 1 {
+		t.Fatalf("WithDetails=%+v", e3)
+	}
+	// Ensure copy (not shared).
+	d["a"] = 2
+	if e3.Details["a"] != 1 {
+		t.Fatalf("expected details map copied")
+	}
+}
+
+func TestOptional_TriStateSemantics(t *testing.T) {
+	t.Parallel()
+
+	u := Unspecified[string]()
+	if u.IsSpecified() || u.IsNull() || u.Value() != "" {
+		t.Fatalf("unspecified=%+v", u)
+	}
+
+	n := Null[string]()
+	if !n.IsSpecified() || !n.IsNull() {
+		t.Fatalf("null=%+v", n)
+	}
+
+	s := Some("x")
+	if !s.IsSpecified() || s.IsNull() || s.Value() != "x" {
+		t.Fatalf("some=%+v", s)
+	}
+}
+
+func TestService_ListMembers_IncludeInactiveAndIncludesInactiveCaller(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	repo := memmemberrepo.NewRepo()
+	clk := memclock.NewManualClock(time.Unix(100, 0).UTC())
+	svc := NewService(repo, clk)
+
+	now := clk.Now()
+	_ = repo.Create(ctx, portmemberrepo.Member{ID: "m1", Subject: "sub-1", DisplayName: "Zoe", Email: "zoe@example.com", IsActive: false, CreatedAt: now, UpdatedAt: now})
+	_ = repo.Create(ctx, portmemberrepo.Member{ID: "m2", Subject: "sub-2", DisplayName: "Alice", Email: "alice@example.com", IsActive: true, CreatedAt: now, UpdatedAt: now})
+	_ = repo.Create(ctx, portmemberrepo.Member{ID: "m3", Subject: "sub-3", DisplayName: "Bob", Email: "bob@example.com", IsActive: false, CreatedAt: now, UpdatedAt: now})
+
+	// includeInactive=false should still include inactive caller ("sub-1"), but not other inactive members.
+	got, err := svc.ListMembers(ctx, domain.SubjectID("sub-1"), false)
+	if err != nil {
+		t.Fatalf("ListMembers: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len=%d want=2", len(got))
+	}
+	// Sorted case-insensitively by displayName.
+	if got[0].ID != "m2" || got[1].ID != "m1" {
+		t.Fatalf("order=%v", []domain.MemberID{got[0].ID, got[1].ID})
+	}
+
+	// includeInactive=true returns all members (still sorted).
+	got2, err := svc.ListMembers(ctx, domain.SubjectID("sub-1"), true)
+	if err != nil {
+		t.Fatalf("ListMembers(includeInactive=true): %v", err)
+	}
+	if len(got2) != 3 {
+		t.Fatalf("len=%d want=3", len(got2))
+	}
+}
+
+func TestService_UpdateMyMemberProfile_EmailUniquenessAndVehicleProfilePatch(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	repo := memmemberrepo.NewRepo()
+	clk := memclock.NewManualClock(time.Unix(100, 0).UTC())
+	svc := NewService(repo, clk)
+
+	// Create two members.
+	_, err := svc.CreateMyMember(ctx, "sub-1", CreateMyMemberInput{DisplayName: "Alice", Email: "alice@example.com"})
+	if err != nil {
+		t.Fatalf("CreateMyMember: %v", err)
+	}
+	_, err = svc.CreateMyMember(ctx, "sub-2", CreateMyMemberInput{DisplayName: "Bob", Email: "bob@example.com"})
+	if err != nil {
+		t.Fatalf("CreateMyMember2: %v", err)
+	}
+
+	// Attempt to change sub-1's email to bob@example.com should conflict.
+	_, err = svc.UpdateMyMemberProfile(ctx, "sub-1", UpdateMyMemberProfileInput{
+		Email: Some("bob@example.com"),
+	})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	ae := (*Error)(nil)
+	if !errors.As(err, &ae) || ae.Status != 409 || ae.Code != "EMAIL_ALREADY_IN_USE" {
+		t.Fatalf("err=%v", err)
+	}
+
+	// Apply a vehicle profile patch to nil existing profile.
+	updated, err := svc.UpdateMyMemberProfile(ctx, "sub-1", UpdateMyMemberProfileInput{
+		VehicleProfile: Some(VehicleProfilePatch{
+			Make:  Some("Toyota"),
+			Model: Some("4Runner"),
+		}),
+	})
+	if err != nil {
+		t.Fatalf("UpdateMyMemberProfile(vehicle): %v", err)
+	}
+	if updated.VehicleProfile == nil || updated.VehicleProfile.Make == nil || *updated.VehicleProfile.Make != "Toyota" {
+		t.Fatalf("vehicleProfile=%+v", updated.VehicleProfile)
+	}
+
+	// Clear a field via null.
+	updated2, err := svc.UpdateMyMemberProfile(ctx, "sub-1", UpdateMyMemberProfileInput{
+		VehicleProfile: Some(VehicleProfilePatch{
+			Make: Null[string](),
+		}),
+	})
+	if err != nil {
+		t.Fatalf("UpdateMyMemberProfile(vehicle clear): %v", err)
+	}
+	if updated2.VehicleProfile == nil || updated2.VehicleProfile.Make != nil {
+		t.Fatalf("expected Make cleared: %+v", updated2.VehicleProfile)
+	}
+}
+
+func TestService_AnonymizeAndDeactivateMyMember_ScrubsFields(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	repo := memmemberrepo.NewRepo()
+	clk := memclock.NewManualClock(time.Unix(100, 0).UTC())
+	svc := NewService(repo, clk)
+
+	// Create member with extra fields.
+	gae := "alias@example.com"
+	_, err := svc.CreateMyMember(ctx, "sub-1", CreateMyMemberInput{
+		DisplayName:     "Alice",
+		Email:           "alice@example.com",
+		GroupAliasEmail: &gae,
+		VehicleProfile: &VehicleProfilePatch{
+			Make: Some("Toyota"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateMyMember: %v", err)
+	}
+
+	clk.Add(10 * time.Second)
+	if err := svc.AnonymizeAndDeactivateMyMember(ctx, "sub-1"); err != nil {
+		t.Fatalf("AnonymizeAndDeactivateMyMember: %v", err)
+	}
+
+	// Fetch directly from repo to validate persistence changes.
+	m, err := repo.GetBySubject(ctx, "sub-1")
+	if err != nil {
+		t.Fatalf("GetBySubject: %v", err)
+	}
+	if m.IsActive {
+		t.Fatalf("expected inactive")
+	}
+	if m.DisplayName != "Deleted member" {
+		t.Fatalf("displayName=%q", m.DisplayName)
+	}
+	if m.GroupAliasEmail != nil || m.VehicleProfile != nil {
+		t.Fatalf("expected groupAliasEmail and vehicleProfile cleared")
+	}
+	if m.Email == "alice@example.com" || m.Email == "" {
+		t.Fatalf("expected email placeholder, got=%q", m.Email)
+	}
+
+	// App-layer profile lookup should now behave as not provisioned.
+	_, err = svc.GetMyMemberProfile(ctx, "sub-1")
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	ae := (*Error)(nil)
+	if !errors.As(err, &ae) || ae.Status != 404 || ae.Code != "MEMBER_NOT_PROVISIONED" {
+		t.Fatalf("err=%v", err)
+	}
+}

--- a/internal/app/trips/edge_cases_test.go
+++ b/internal/app/trips/edge_cases_test.go
@@ -1,0 +1,247 @@
+package trips_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	memmemberrepo "github.com/Overland-East-Bay/trip-planner-api/internal/adapters/memory/memberrepo"
+	memrsvprepo "github.com/Overland-East-Bay/trip-planner-api/internal/adapters/memory/rsvprepo"
+	memtriprepo "github.com/Overland-East-Bay/trip-planner-api/internal/adapters/memory/triprepo"
+	"github.com/Overland-East-Bay/trip-planner-api/internal/app/trips"
+	"github.com/Overland-East-Bay/trip-planner-api/internal/domain"
+	portrsvprepo "github.com/Overland-East-Bay/trip-planner-api/internal/ports/out/rsvprepo"
+	porttriprepo "github.com/Overland-East-Bay/trip-planner-api/internal/ports/out/triprepo"
+)
+
+func TestService_CreateTripDraft_RejectsMissingCallerAndEmptyName(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	membersRepo := memmemberrepo.NewRepo()
+	tripsRepo := memtriprepo.NewRepo()
+	rsvpsRepo := memrsvprepo.NewRepo()
+	svc := trips.NewService(tripsRepo, membersRepo, rsvpsRepo)
+
+	// Missing caller member.
+	_, err := svc.CreateTripDraft(ctx, "missing", trips.CreateTripDraftInput{Name: "Trip"})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	ae := (*trips.Error)(nil)
+	if !errors.As(err, &ae) || ae.Status != 422 {
+		t.Fatalf("err=%v", err)
+	}
+
+	// Empty name after normalization.
+	provisionMember(t, membersRepo, "m1")
+	_, err = svc.CreateTripDraft(ctx, "m1", trips.CreateTripDraftInput{Name: "   \n\t"})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !errors.As(err, &ae) || ae.Status != 422 {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestService_SetMyRSVP_RejectsInvalidResponse(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	membersRepo := memmemberrepo.NewRepo()
+	tripsRepo := memtriprepo.NewRepo()
+	rsvpsRepo := memrsvprepo.NewRepo()
+	provisionMember(t, membersRepo, "m1")
+
+	svc := trips.NewService(tripsRepo, membersRepo, rsvpsRepo)
+
+	name := "Trip"
+	cap := 1
+	att := 0
+	now := time.Unix(1, 0).UTC()
+	_ = tripsRepo.Create(ctx, porttriprepo.Trip{
+		ID:                 "tp",
+		Status:             porttriprepo.StatusPublished,
+		Name:               &name,
+		CapacityRigs:       &cap,
+		AttendingRigs:      &att,
+		CreatorMemberID:    "m1",
+		OrganizerMemberIDs: []domain.MemberID{"m1"},
+		DraftVisibility:    porttriprepo.DraftVisibilityPublic,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	})
+
+	_, err := svc.SetMyRSVP(ctx, "m1", "tp", domain.RSVPResponse("MAYBE"))
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	ae := (*trips.Error)(nil)
+	if !errors.As(err, &ae) || ae.Status != 422 {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestService_GetTripRSVPSummary_DraftNotAvailable(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	membersRepo := memmemberrepo.NewRepo()
+	tripsRepo := memtriprepo.NewRepo()
+	rsvpsRepo := memrsvprepo.NewRepo()
+	provisionMember(t, membersRepo, "m1")
+
+	svc := trips.NewService(tripsRepo, membersRepo, rsvpsRepo)
+
+	name := "Draft"
+	now := time.Unix(2, 0).UTC()
+	_ = tripsRepo.Create(ctx, porttriprepo.Trip{
+		ID:                 "td",
+		Status:             porttriprepo.StatusDraft,
+		Name:               &name,
+		CreatorMemberID:    "m1",
+		OrganizerMemberIDs: []domain.MemberID{"m1"},
+		DraftVisibility:    porttriprepo.DraftVisibilityPrivate,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	})
+
+	_, err := svc.GetTripRSVPSummary(ctx, "m1", "td")
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	ae := (*trips.Error)(nil)
+	if !errors.As(err, &ae) || ae.Status != 409 || ae.Code != "RSVP_NOT_AVAILABLE" {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestService_UpdateTrip_ValidatesCapacityAndPublishedInvariant(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	membersRepo := memmemberrepo.NewRepo()
+	tripsRepo := memtriprepo.NewRepo()
+	rsvpsRepo := memrsvprepo.NewRepo()
+	provisionMember(t, membersRepo, "m1")
+
+	svc := trips.NewService(tripsRepo, membersRepo, rsvpsRepo)
+
+	name := "Trip"
+	cap := 5
+	att := 4
+	now := time.Unix(3, 0).UTC()
+	_ = tripsRepo.Create(ctx, porttriprepo.Trip{
+		ID:                 "tp",
+		Status:             porttriprepo.StatusPublished,
+		Name:               &name,
+		CapacityRigs:       &cap,
+		AttendingRigs:      &att,
+		CreatorMemberID:    "m1",
+		OrganizerMemberIDs: []domain.MemberID{"m1"},
+		DraftVisibility:    porttriprepo.DraftVisibilityPublic,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	})
+
+	// Capacity must be >= 1.
+	_, err := svc.UpdateTrip(ctx, "m1", "tp", trips.UpdateTripInput{
+		CapacityRigs: trips.Some(0),
+	})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	ae := (*trips.Error)(nil)
+	if !errors.As(err, &ae) || ae.Status != 422 {
+		t.Fatalf("err=%v", err)
+	}
+
+	// Cannot reduce below attending rigs.
+	_, err = svc.UpdateTrip(ctx, "m1", "tp", trips.UpdateTripInput{
+		CapacityRigs: trips.Some(3),
+	})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !errors.As(err, &ae) || ae.Status != 409 || ae.Code != "CAPACITY_BELOW_ATTENDANCE" {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestService_AddTripOrganizer_RejectsUnknownTargetMember(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	membersRepo := memmemberrepo.NewRepo()
+	tripsRepo := memtriprepo.NewRepo()
+	rsvpsRepo := memrsvprepo.NewRepo()
+	provisionMember(t, membersRepo, "m1")
+
+	svc := trips.NewService(tripsRepo, membersRepo, rsvpsRepo)
+
+	name := "Trip"
+	now := time.Unix(4, 0).UTC()
+	_ = tripsRepo.Create(ctx, porttriprepo.Trip{
+		ID:                 "tp",
+		Status:             porttriprepo.StatusDraft,
+		Name:               &name,
+		CreatorMemberID:    "m1",
+		OrganizerMemberIDs: []domain.MemberID{"m1"},
+		DraftVisibility:    porttriprepo.DraftVisibilityPublic,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	})
+
+	_, err := svc.AddTripOrganizer(ctx, "m1", "tp", "missing")
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	ae := (*trips.Error)(nil)
+	if !errors.As(err, &ae) || ae.Status != 422 {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestService_DeleteAllRSVPsByMember_UpdatesAttendanceUsingRepoCounts(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	membersRepo := memmemberrepo.NewRepo()
+	tripsRepo := memtriprepo.NewRepo()
+	rsvpsRepo := memrsvprepo.NewRepo()
+	provisionMember(t, membersRepo, "m1")
+	provisionMember(t, membersRepo, "m2")
+
+	svc := trips.NewService(tripsRepo, membersRepo, rsvpsRepo)
+
+	name := "Trip"
+	cap := 10
+	att := 0
+	now := time.Unix(5, 0).UTC()
+	_ = tripsRepo.Create(ctx, porttriprepo.Trip{
+		ID:                 "t1",
+		Status:             porttriprepo.StatusPublished,
+		Name:               &name,
+		CapacityRigs:       &cap,
+		AttendingRigs:      &att,
+		CreatorMemberID:    "m1",
+		OrganizerMemberIDs: []domain.MemberID{"m1"},
+		DraftVisibility:    porttriprepo.DraftVisibilityPublic,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	})
+
+	_ = rsvpsRepo.Upsert(ctx, portrsvprepo.RSVP{TripID: "t1", MemberID: "m1", Status: portrsvprepo.StatusYes, UpdatedAt: now})
+	_ = rsvpsRepo.Upsert(ctx, portrsvprepo.RSVP{TripID: "t1", MemberID: "m2", Status: portrsvprepo.StatusYes, UpdatedAt: now})
+
+	if err := svc.DeleteAllRSVPsByMember(ctx, "m1"); err != nil {
+		t.Fatalf("DeleteAllRSVPsByMember: %v", err)
+	}
+
+	// Recomputed attendance should now be 1 (m2 only).
+	t1, _ := tripsRepo.GetByID(ctx, "t1")
+	if t1.AttendingRigs == nil || *t1.AttendingRigs != 1 {
+		t.Fatalf("attending=%v want=1", t1.AttendingRigs)
+	}
+}

--- a/internal/app/trips/edge_cases_test.go
+++ b/internal/app/trips/edge_cases_test.go
@@ -245,3 +245,252 @@ func TestService_DeleteAllRSVPsByMember_UpdatesAttendanceUsingRepoCounts(t *test
 		t.Fatalf("attending=%v want=1", t1.AttendingRigs)
 	}
 }
+
+func TestService_NewService_DefaultTripIDGeneratorProducesNonEmptyID(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	membersRepo := memmemberrepo.NewRepo()
+	tripsRepo := memtriprepo.NewRepo()
+	rsvpsRepo := memrsvprepo.NewRepo()
+	provisionMember(t, membersRepo, "m1")
+
+	svc := trips.NewService(tripsRepo, membersRepo, rsvpsRepo)
+	created, err := svc.CreateTripDraft(ctx, "m1", trips.CreateTripDraftInput{Name: "Trip"})
+	if err != nil {
+		t.Fatalf("CreateTripDraft: %v", err)
+	}
+	if created.ID == "" {
+		t.Fatalf("expected non-empty id")
+	}
+}
+
+func TestService_GetTripRSVPSummary_NotVisibleReturns404(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	membersRepo := memmemberrepo.NewRepo()
+	tripsRepo := memtriprepo.NewRepo()
+	rsvpsRepo := memrsvprepo.NewRepo()
+	provisionMember(t, membersRepo, "m1")
+	provisionMember(t, membersRepo, "m2")
+
+	svc := trips.NewService(tripsRepo, membersRepo, rsvpsRepo)
+
+	name := "Draft"
+	now := time.Unix(6, 0).UTC()
+	_ = tripsRepo.Create(ctx, porttriprepo.Trip{
+		ID:                 "td-private",
+		Status:             porttriprepo.StatusDraft,
+		Name:               &name,
+		CreatorMemberID:    "m2",
+		OrganizerMemberIDs: []domain.MemberID{"m2"},
+		DraftVisibility:    porttriprepo.DraftVisibilityPrivate,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	})
+
+	_, err := svc.GetTripRSVPSummary(ctx, "m1", "td-private")
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	ae := (*trips.Error)(nil)
+	if !errors.As(err, &ae) || ae.Status != 404 {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestService_UpdateTrip_ClearsMeetingLocationWithNull(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	membersRepo := memmemberrepo.NewRepo()
+	tripsRepo := memtriprepo.NewRepo()
+	rsvpsRepo := memrsvprepo.NewRepo()
+	provisionMember(t, membersRepo, "m1")
+
+	svc := trips.NewService(tripsRepo, membersRepo, rsvpsRepo)
+
+	name := "Trip"
+	now := time.Unix(7, 0).UTC()
+	addr := "123 Main"
+	_ = tripsRepo.Create(ctx, porttriprepo.Trip{
+		ID:                 "tp",
+		Status:             porttriprepo.StatusDraft,
+		Name:               &name,
+		CreatorMemberID:    "m1",
+		OrganizerMemberIDs: []domain.MemberID{"m1"},
+		DraftVisibility:    porttriprepo.DraftVisibilityPublic,
+		MeetingLocation:    &domain.Location{Label: "Meet", Address: &addr},
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	})
+
+	td, err := svc.UpdateTrip(ctx, "m1", "tp", trips.UpdateTripInput{
+		MeetingLocation: trips.Null[*trips.LocationPatch](),
+	})
+	if err != nil {
+		t.Fatalf("UpdateTrip: %v", err)
+	}
+	if td.MeetingLocation != nil {
+		t.Fatalf("expected meetingLocation cleared")
+	}
+}
+
+func TestService_CancelTrip_NonVisibleStatusReturnsNotFound(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	membersRepo := memmemberrepo.NewRepo()
+	tripsRepo := memtriprepo.NewRepo()
+	rsvpsRepo := memrsvprepo.NewRepo()
+	provisionMember(t, membersRepo, "m1")
+
+	svc := trips.NewService(tripsRepo, membersRepo, rsvpsRepo)
+
+	name := "Trip"
+	now := time.Unix(8, 0).UTC()
+	_ = tripsRepo.Create(ctx, porttriprepo.Trip{
+		ID:                 "tp",
+		Status:             porttriprepo.Status("WEIRD"),
+		Name:               &name,
+		CreatorMemberID:    "m1",
+		OrganizerMemberIDs: []domain.MemberID{"m1"},
+		DraftVisibility:    porttriprepo.DraftVisibilityPublic,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	})
+
+	_, err := svc.CancelTrip(ctx, "m1", "tp")
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	ae := (*trips.Error)(nil)
+	// Non-visible trips should fail closed as 404 (even if they exist).
+	if !errors.As(err, &ae) || ae.Status != 404 || ae.Code != "TRIP_NOT_FOUND" {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestService_UpdateTrip_DraftAuthorizationAndNameValidation(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	membersRepo := memmemberrepo.NewRepo()
+	tripsRepo := memtriprepo.NewRepo()
+	rsvpsRepo := memrsvprepo.NewRepo()
+	provisionMember(t, membersRepo, "m1")
+	provisionMember(t, membersRepo, "m2")
+
+	svc := trips.NewService(tripsRepo, membersRepo, rsvpsRepo)
+
+	name := "Trip"
+	now := time.Unix(9, 0).UTC()
+	_ = tripsRepo.Create(ctx, porttriprepo.Trip{
+		ID:                 "td-priv",
+		Status:             porttriprepo.StatusDraft,
+		Name:               &name,
+		CreatorMemberID:    "m1",
+		OrganizerMemberIDs: []domain.MemberID{"m1"},
+		DraftVisibility:    porttriprepo.DraftVisibilityPrivate,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	})
+	_ = tripsRepo.Create(ctx, porttriprepo.Trip{
+		ID:                 "td-pub",
+		Status:             porttriprepo.StatusDraft,
+		Name:               &name,
+		CreatorMemberID:    "m1",
+		OrganizerMemberIDs: []domain.MemberID{"m1"},
+		DraftVisibility:    porttriprepo.DraftVisibilityPublic,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	})
+
+	// Private draft: only creator may update.
+	_, err := svc.UpdateTrip(ctx, "m2", "td-priv", trips.UpdateTripInput{Name: trips.Some("New")})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	ae := (*trips.Error)(nil)
+	if !errors.As(err, &ae) || ae.Status != 404 {
+		t.Fatalf("err=%v", err)
+	}
+
+	// Public draft: only organizers may update.
+	_, err = svc.UpdateTrip(ctx, "m2", "td-pub", trips.UpdateTripInput{Name: trips.Some("New")})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !errors.As(err, &ae) || ae.Status != 404 {
+		t.Fatalf("err=%v", err)
+	}
+
+	// Name cannot be null.
+	_, err = svc.UpdateTrip(ctx, "m1", "td-priv", trips.UpdateTripInput{Name: trips.Null[string]()})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !errors.As(err, &ae) || ae.Status != 422 {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestService_UpdateTrip_CanceledCannotBeModified(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	membersRepo := memmemberrepo.NewRepo()
+	tripsRepo := memtriprepo.NewRepo()
+	rsvpsRepo := memrsvprepo.NewRepo()
+	provisionMember(t, membersRepo, "m1")
+
+	svc := trips.NewService(tripsRepo, membersRepo, rsvpsRepo)
+
+	name := "Trip"
+	now := time.Unix(10, 0).UTC()
+	_ = tripsRepo.Create(ctx, porttriprepo.Trip{
+		ID:                 "tc",
+		Status:             porttriprepo.StatusCanceled,
+		Name:               &name,
+		CreatorMemberID:    "m1",
+		OrganizerMemberIDs: []domain.MemberID{"m1"},
+		DraftVisibility:    porttriprepo.DraftVisibilityPublic,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	})
+
+	_, err := svc.UpdateTrip(ctx, "m1", "tc", trips.UpdateTripInput{Name: trips.Some("New")})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	ae := (*trips.Error)(nil)
+	if !errors.As(err, &ae) || ae.Status != 409 || ae.Code != "TRIP_CANCELED" {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestService_CreateTripDraft_IDConflictReturns409(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	membersRepo := memmemberrepo.NewRepo()
+	tripsRepo := memtriprepo.NewRepo()
+	rsvpsRepo := memrsvprepo.NewRepo()
+	provisionMember(t, membersRepo, "m1")
+
+	svc := trips.NewService(tripsRepo, membersRepo, rsvpsRepo)
+	svc.SetNewTripIDForTest(func() domain.TripID { return "fixed-id" })
+
+	if _, err := svc.CreateTripDraft(ctx, "m1", trips.CreateTripDraftInput{Name: "Trip"}); err != nil {
+		t.Fatalf("CreateTripDraft: %v", err)
+	}
+	_, err := svc.CreateTripDraft(ctx, "m1", trips.CreateTripDraftInput{Name: "Trip"})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	ae := (*trips.Error)(nil)
+	if !errors.As(err, &ae) || ae.Status != 409 || ae.Code != "TRIP_ID_CONFLICT" {
+		t.Fatalf("err=%v", err)
+	}
+}

--- a/internal/app/trips/service_test.go
+++ b/internal/app/trips/service_test.go
@@ -3,6 +3,7 @@ package trips_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -365,4 +366,533 @@ func TestService_RSVP_Summary_SortsAndOmitsUnset(t *testing.T) {
 	if len(sum.NotAttendingMembers) != 1 || sum.NotAttendingMembers[0].ID != "m1" {
 		t.Fatalf("NotAttendingMembers=%v", sum.NotAttendingMembers)
 	}
+}
+
+func TestService_DeleteAllRSVPsByMember_RecomputesAttendanceAndIgnoresMissingTrips(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	membersRepo := memmemberrepo.NewRepo()
+	tripsRepo := memtriprepo.NewRepo()
+	rsvpsRepo := memrsvprepo.NewRepo()
+	provisionMember(t, membersRepo, "m1")
+	provisionMember(t, membersRepo, "m2")
+
+	svc := trips.NewService(tripsRepo, membersRepo, rsvpsRepo)
+
+	name := "Trip"
+	cap := 10
+	now := time.Unix(800, 0).UTC()
+	att0 := 0
+
+	_ = tripsRepo.Create(ctx, porttriprepo.Trip{
+		ID:                 "t1",
+		Status:             porttriprepo.StatusPublished,
+		Name:               &name,
+		CapacityRigs:       &cap,
+		AttendingRigs:      &att0,
+		CreatorMemberID:    "m1",
+		OrganizerMemberIDs: []domain.MemberID{"m1"},
+		DraftVisibility:    porttriprepo.DraftVisibilityPublic,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	})
+	_ = tripsRepo.Create(ctx, porttriprepo.Trip{
+		ID:                 "t2",
+		Status:             porttriprepo.StatusPublished,
+		Name:               &name,
+		CapacityRigs:       &cap,
+		AttendingRigs:      &att0,
+		CreatorMemberID:    "m1",
+		OrganizerMemberIDs: []domain.MemberID{"m1"},
+		DraftVisibility:    porttriprepo.DraftVisibilityPublic,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	})
+
+	// Seed RSVPs for m1 across two real trips, plus one missing trip (should be ignored).
+	_ = rsvpsRepo.Upsert(ctx, portrsvprepo.RSVP{TripID: "t1", MemberID: "m1", Status: portrsvprepo.StatusYes, UpdatedAt: now})
+	_ = rsvpsRepo.Upsert(ctx, portrsvprepo.RSVP{TripID: "t2", MemberID: "m1", Status: portrsvprepo.StatusNo, UpdatedAt: now})
+	_ = rsvpsRepo.Upsert(ctx, portrsvprepo.RSVP{TripID: "missing", MemberID: "m1", Status: portrsvprepo.StatusYes, UpdatedAt: now})
+	_ = rsvpsRepo.Upsert(ctx, portrsvprepo.RSVP{TripID: "t1", MemberID: "m2", Status: portrsvprepo.StatusYes, UpdatedAt: now})
+
+	if err := svc.DeleteAllRSVPsByMember(ctx, "m1"); err != nil {
+		t.Fatalf("DeleteAllRSVPsByMember: %v", err)
+	}
+
+	// m1 RSVPs should be gone.
+	if _, err := rsvpsRepo.Get(ctx, "t1", "m1"); err == nil {
+		t.Fatalf("expected m1 RSVP deleted for t1")
+	}
+	if _, err := rsvpsRepo.Get(ctx, "t2", "m1"); err == nil {
+		t.Fatalf("expected m1 RSVP deleted for t2")
+	}
+
+	// Attendance should be recomputed: only m2 has YES on t1 => 1. t2 has no YES => 0.
+	t1, _ := tripsRepo.GetByID(ctx, "t1")
+	if t1.AttendingRigs == nil || *t1.AttendingRigs != 1 {
+		t.Fatalf("t1.AttendingRigs=%v want=1", t1.AttendingRigs)
+	}
+	t2, _ := tripsRepo.GetByID(ctx, "t2")
+	if t2.AttendingRigs == nil || *t2.AttendingRigs != 0 {
+		t.Fatalf("t2.AttendingRigs=%v want=0", t2.AttendingRigs)
+	}
+}
+
+func TestService_ListVisibleTripsForMember_MapsTripSummaries(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	membersRepo := memmemberrepo.NewRepo()
+	tripsRepo := memtriprepo.NewRepo()
+	rsvpsRepo := memrsvprepo.NewRepo()
+	provisionMember(t, membersRepo, "m1")
+
+	svc := trips.NewService(tripsRepo, membersRepo, rsvpsRepo)
+
+	name1 := "One"
+	name2 := "Two"
+	now := time.Unix(900, 0).UTC()
+	_ = tripsRepo.Create(ctx, porttriprepo.Trip{ID: "t1", Status: porttriprepo.StatusPublished, Name: &name1, CreatedAt: now, UpdatedAt: now})
+	_ = tripsRepo.Create(ctx, porttriprepo.Trip{ID: "t2", Status: porttriprepo.StatusCanceled, Name: &name2, CreatedAt: now, UpdatedAt: now})
+	_ = tripsRepo.Create(ctx, porttriprepo.Trip{ID: "td", Status: porttriprepo.StatusDraft, Name: &name2, DraftVisibility: porttriprepo.DraftVisibilityPrivate, CreatorMemberID: "m1", OrganizerMemberIDs: []domain.MemberID{"m1"}, CreatedAt: now, UpdatedAt: now})
+
+	out, err := svc.ListVisibleTripsForMember(ctx, "m1")
+	if err != nil {
+		t.Fatalf("ListVisibleTripsForMember: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("len=%d want=2", len(out))
+	}
+	ids := []string{string(out[0].ID), string(out[1].ID)}
+	if !containsAll(ids, []string{"t1", "t2"}) {
+		t.Fatalf("ids=%v want contains t1,t2", ids)
+	}
+}
+
+func TestService_ListMyDraftTrips_FiltersByVisibilityRules(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	membersRepo := memmemberrepo.NewRepo()
+	tripsRepo := memtriprepo.NewRepo()
+	rsvpsRepo := memrsvprepo.NewRepo()
+	provisionMember(t, membersRepo, "m1")
+	provisionMember(t, membersRepo, "m2")
+
+	svc := trips.NewService(tripsRepo, membersRepo, rsvpsRepo)
+
+	now := time.Unix(1000, 0).UTC()
+	name := "Draft"
+	_ = tripsRepo.Create(ctx, porttriprepo.Trip{
+		ID:                 "pub-org",
+		Status:             porttriprepo.StatusDraft,
+		Name:               &name,
+		DraftVisibility:    porttriprepo.DraftVisibilityPublic,
+		OrganizerMemberIDs: []domain.MemberID{"m1"},
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	})
+	_ = tripsRepo.Create(ctx, porttriprepo.Trip{
+		ID:              "priv-creator",
+		Status:          porttriprepo.StatusDraft,
+		Name:            &name,
+		DraftVisibility: porttriprepo.DraftVisibilityPrivate,
+		CreatorMemberID: "m1",
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	})
+	_ = tripsRepo.Create(ctx, porttriprepo.Trip{
+		ID:                 "pub-not-org",
+		Status:             porttriprepo.StatusDraft,
+		Name:               &name,
+		DraftVisibility:    porttriprepo.DraftVisibilityPublic,
+		OrganizerMemberIDs: []domain.MemberID{"m2"},
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	})
+	_ = tripsRepo.Create(ctx, porttriprepo.Trip{
+		ID:              "priv-not-creator",
+		Status:          porttriprepo.StatusDraft,
+		Name:            &name,
+		DraftVisibility: porttriprepo.DraftVisibilityPrivate,
+		CreatorMemberID: "m2",
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	})
+
+	out, err := svc.ListMyDraftTrips(ctx, "m1")
+	if err != nil {
+		t.Fatalf("ListMyDraftTrips: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("len=%d want=2", len(out))
+	}
+	ids := []string{string(out[0].ID), string(out[1].ID)}
+	if !containsAll(ids, []string{"pub-org", "priv-creator"}) {
+		t.Fatalf("ids=%v want contains pub-org,priv-creator", ids)
+	}
+}
+
+func TestService_GetTripDetails_DraftOmitsRSVPFields(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	membersRepo := memmemberrepo.NewRepo()
+	tripsRepo := memtriprepo.NewRepo()
+	rsvpsRepo := memrsvprepo.NewRepo()
+	provisionMember(t, membersRepo, "m1")
+
+	svc := trips.NewService(tripsRepo, membersRepo, rsvpsRepo)
+
+	name := "Draft"
+	now := time.Unix(1100, 0).UTC()
+	_ = tripsRepo.Create(ctx, porttriprepo.Trip{
+		ID:                 "td1",
+		Status:             porttriprepo.StatusDraft,
+		Name:               &name,
+		CreatorMemberID:    "m1",
+		OrganizerMemberIDs: []domain.MemberID{"m1"},
+		DraftVisibility:    porttriprepo.DraftVisibilityPrivate,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	})
+
+	td, err := svc.GetTripDetails(ctx, "m1", "td1")
+	if err != nil {
+		t.Fatalf("GetTripDetails: %v", err)
+	}
+	if td.Status != domain.TripStatusDraft {
+		t.Fatalf("status=%s", td.Status)
+	}
+	if td.RSVPActionsEnabled {
+		t.Fatalf("RSVPActionsEnabled should be false for drafts")
+	}
+	if td.RSVPSummary != nil || td.MyRSVP != nil {
+		t.Fatalf("expected RSVP fields omitted for draft: %+v", td)
+	}
+}
+
+func TestService_GetTripDetails_PublishedIncludesRSVPSummaryAndMyRSVPWhenPresent(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	membersRepo := memmemberrepo.NewRepo()
+	tripsRepo := memtriprepo.NewRepo()
+	rsvpsRepo := memrsvprepo.NewRepo()
+
+	// Two members to populate summary + organizer expansion.
+	now := time.Unix(1200, 0).UTC()
+	_ = membersRepo.Create(ctx, portmemberrepo.Member{ID: "m1", Subject: "sub-m1", DisplayName: "Alice", Email: "m1@example.com", IsActive: true, CreatedAt: now, UpdatedAt: now})
+	_ = membersRepo.Create(ctx, portmemberrepo.Member{ID: "m2", Subject: "sub-m2", DisplayName: "Bob", Email: "m2@example.com", IsActive: true, CreatedAt: now, UpdatedAt: now})
+
+	svc := trips.NewService(tripsRepo, membersRepo, rsvpsRepo)
+
+	name := "Trip"
+	desc := " Desc "
+	diff := "Easy"
+	comms := "FRS"
+	recs := "Spare tire"
+	start := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC)
+	cap := 5
+	att := 0
+	addr := "123 Main"
+	_ = tripsRepo.Create(ctx, porttriprepo.Trip{
+		ID:                          "tp1",
+		Status:                      porttriprepo.StatusPublished,
+		Name:                        &name,
+		Description:                 &desc,
+		DifficultyText:              &diff,
+		CommsRequirementsText:       &comms,
+		RecommendedRequirementsText: &recs,
+		StartDate:                   &start,
+		EndDate:                     &end,
+		CapacityRigs:                &cap,
+		AttendingRigs:               &att,
+		MeetingLocation:             &domain.Location{Label: "Meet", Address: &addr},
+		CreatorMemberID:             "m1",
+		OrganizerMemberIDs:          []domain.MemberID{"m1", "m2"},
+		DraftVisibility:             porttriprepo.DraftVisibilityPublic,
+		CreatedAt:                   now,
+		UpdatedAt:                   now,
+	})
+
+	// Seed RSVPs: m1 YES, m2 NO.
+	_ = rsvpsRepo.Upsert(ctx, portrsvprepo.RSVP{TripID: "tp1", MemberID: "m1", Status: portrsvprepo.StatusYes, UpdatedAt: now})
+	_ = rsvpsRepo.Upsert(ctx, portrsvprepo.RSVP{TripID: "tp1", MemberID: "m2", Status: portrsvprepo.StatusNo, UpdatedAt: now})
+
+	td, err := svc.GetTripDetails(ctx, "m1", "tp1")
+	if err != nil {
+		t.Fatalf("GetTripDetails: %v", err)
+	}
+	if !td.RSVPActionsEnabled {
+		t.Fatalf("RSVPActionsEnabled should be true for published trips")
+	}
+	if td.RSVPSummary == nil || td.MyRSVP == nil {
+		t.Fatalf("expected RSVP summary and myRSVP present for m1")
+	}
+	if td.MyRSVP.Response != domain.RSVPResponseYes {
+		t.Fatalf("my=%+v", td.MyRSVP)
+	}
+	if td.RSVPSummary.AttendingRigs != 1 {
+		t.Fatalf("AttendingRigs=%d want=1", td.RSVPSummary.AttendingRigs)
+	}
+}
+
+func TestService_GetMyRSVPForTrip_HappyPathAndEdgeCases(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	membersRepo := memmemberrepo.NewRepo()
+	tripsRepo := memtriprepo.NewRepo()
+	rsvpsRepo := memrsvprepo.NewRepo()
+	provisionMember(t, membersRepo, "m1")
+
+	svc := trips.NewService(tripsRepo, membersRepo, rsvpsRepo)
+
+	name := "Trip"
+	now := time.Unix(1300, 0).UTC()
+	_ = tripsRepo.Create(ctx, porttriprepo.Trip{ID: "draft", Status: porttriprepo.StatusDraft, Name: &name, DraftVisibility: porttriprepo.DraftVisibilityPrivate, CreatorMemberID: "m1", OrganizerMemberIDs: []domain.MemberID{"m1"}, CreatedAt: now, UpdatedAt: now})
+	_ = tripsRepo.Create(ctx, porttriprepo.Trip{ID: "pub", Status: porttriprepo.StatusPublished, Name: &name, CreatedAt: now, UpdatedAt: now})
+
+	// Draft => RSVP not available.
+	if _, err := svc.GetMyRSVPForTrip(ctx, "m1", "draft"); err == nil {
+		t.Fatalf("expected error for draft trip")
+	}
+
+	// Published but no RSVP => 404 RSVP_NOT_FOUND.
+	_, err := svc.GetMyRSVPForTrip(ctx, "m1", "pub")
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	ae := (*trips.Error)(nil)
+	if !errors.As(err, &ae) || ae.Status != 404 || ae.Code != "RSVP_NOT_FOUND" {
+		t.Fatalf("err=%v", err)
+	}
+
+	_ = rsvpsRepo.Upsert(ctx, portrsvprepo.RSVP{TripID: "pub", MemberID: "m1", Status: portrsvprepo.StatusNo, UpdatedAt: now})
+	my, err := svc.GetMyRSVPForTrip(ctx, "m1", "pub")
+	if err != nil {
+		t.Fatalf("GetMyRSVPForTrip: %v", err)
+	}
+	if my.Response != domain.RSVPResponseNo {
+		t.Fatalf("my=%+v", my)
+	}
+}
+
+func TestService_SetTripDraftVisibility_ValidatesAndAuthorizes(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	membersRepo := memmemberrepo.NewRepo()
+	tripsRepo := memtriprepo.NewRepo()
+	rsvpsRepo := memrsvprepo.NewRepo()
+	provisionMember(t, membersRepo, "m1")
+	provisionMember(t, membersRepo, "m2")
+
+	svc := trips.NewService(tripsRepo, membersRepo, rsvpsRepo)
+
+	name := "Draft"
+	now := time.Unix(1400, 0).UTC()
+	_ = tripsRepo.Create(ctx, porttriprepo.Trip{
+		ID:                 "td1",
+		Status:             porttriprepo.StatusDraft,
+		Name:               &name,
+		CreatorMemberID:    "m1",
+		OrganizerMemberIDs: []domain.MemberID{"m1"},
+		DraftVisibility:    porttriprepo.DraftVisibilityPrivate,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	})
+
+	// Invalid dv.
+	_, err := svc.SetTripDraftVisibility(ctx, "m1", "td1", domain.DraftVisibility("BOGUS"))
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	ae := (*trips.Error)(nil)
+	if !errors.As(err, &ae) || ae.Status != 422 {
+		t.Fatalf("err=%v", err)
+	}
+
+	// Not creator => 404.
+	_, err = svc.SetTripDraftVisibility(ctx, "m2", "td1", domain.DraftVisibilityPublic)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !errors.As(err, &ae) || ae.Status != 404 {
+		t.Fatalf("err=%v", err)
+	}
+
+	// Happy path: make public.
+	td, err := svc.SetTripDraftVisibility(ctx, "m1", "td1", domain.DraftVisibilityPublic)
+	if err != nil {
+		t.Fatalf("SetTripDraftVisibility: %v", err)
+	}
+	if td.DraftVisibility == nil || *td.DraftVisibility != domain.DraftVisibilityPublic {
+		t.Fatalf("draftVisibility=%v", td.DraftVisibility)
+	}
+}
+
+func TestService_PublishTrip_HappyPathAndAnnouncementCopy(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	membersRepo := memmemberrepo.NewRepo()
+	tripsRepo := memtriprepo.NewRepo()
+	rsvpsRepo := memrsvprepo.NewRepo()
+	provisionMember(t, membersRepo, "m1")
+
+	svc := trips.NewService(tripsRepo, membersRepo, rsvpsRepo)
+
+	name := "Snow Run"
+	desc := "Fun trip"
+	diff := "Easy"
+	comms := "FRS"
+	recs := "Spare tire"
+	start := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC)
+	cap := 8
+	addr := "Trailhead"
+	now := time.Unix(1500, 0).UTC()
+	_ = tripsRepo.Create(ctx, porttriprepo.Trip{
+		ID:                          "tdp",
+		Status:                      porttriprepo.StatusDraft,
+		Name:                        &name,
+		Description:                 &desc,
+		DifficultyText:              &diff,
+		CommsRequirementsText:       &comms,
+		RecommendedRequirementsText: &recs,
+		StartDate:                   &start,
+		EndDate:                     &end,
+		CapacityRigs:                &cap,
+		MeetingLocation:             &domain.Location{Label: "Meet", Address: &addr},
+		CreatorMemberID:             "m1",
+		OrganizerMemberIDs:          []domain.MemberID{"m1"},
+		DraftVisibility:             porttriprepo.DraftVisibilityPublic,
+		CreatedAt:                   now,
+		UpdatedAt:                   now,
+	})
+
+	td, copy, err := svc.PublishTrip(ctx, "m1", "tdp")
+	if err != nil {
+		t.Fatalf("PublishTrip: %v", err)
+	}
+	if td.Status != domain.TripStatusPublished {
+		t.Fatalf("status=%s want=PUBLISHED", td.Status)
+	}
+	if copy == "" || !strings.Contains(copy, "Trip: Snow Run") {
+		t.Fatalf("copy=%q", copy)
+	}
+	if td.AttendingRigs == nil || *td.AttendingRigs != 0 {
+		t.Fatalf("attendingRigs=%v want=0", td.AttendingRigs)
+	}
+
+	// Idempotent publish on already-published trip should return copy.
+	_, copy2, err := svc.PublishTrip(ctx, "m1", "tdp")
+	if err != nil {
+		t.Fatalf("PublishTrip2: %v", err)
+	}
+	if copy2 == "" {
+		t.Fatalf("expected copy2")
+	}
+}
+
+func TestService_UpdateTrip_MeetingLocationPatchAndArtifactReorder(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	membersRepo := memmemberrepo.NewRepo()
+	tripsRepo := memtriprepo.NewRepo()
+	rsvpsRepo := memrsvprepo.NewRepo()
+	provisionMember(t, membersRepo, "m1")
+
+	svc := trips.NewService(tripsRepo, membersRepo, rsvpsRepo)
+
+	name := "Trip"
+	now := time.Unix(1600, 0).UTC()
+	addr := "Old"
+	lat := 1.23
+	lng := 4.56
+	_ = tripsRepo.Create(ctx, porttriprepo.Trip{
+		ID:                 "tp",
+		Status:             porttriprepo.StatusPublished,
+		Name:               &name,
+		CreatorMemberID:    "m1",
+		OrganizerMemberIDs: []domain.MemberID{"m1"},
+		DraftVisibility:    porttriprepo.DraftVisibilityPublic,
+		MeetingLocation:    &domain.Location{Label: "Meet", Address: &addr, Latitude: &lat, Longitude: &lng},
+		Artifacts: []domain.TripArtifact{
+			{ArtifactID: "a1", Type: domain.ArtifactTypeGPX, Title: "A1", URL: "https://example.com/a1"},
+			{ArtifactID: "a2", Type: domain.ArtifactTypeDocument, Title: "A2", URL: "https://example.com/a2"},
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	})
+
+	// Reorder artifacts + clear coordinates + change address; label null should be ignored (kept).
+	patch := &trips.LocationPatch{
+		Label:            trips.Null[string](),
+		Address:          trips.Some("New"),
+		ClearCoordinates: true,
+	}
+	td, err := svc.UpdateTrip(ctx, "m1", "tp", trips.UpdateTripInput{
+		MeetingLocation: trips.Some(patch),
+		ArtifactIDs:     trips.Some([]string{"a2", "a1"}),
+	})
+	if err != nil {
+		t.Fatalf("UpdateTrip: %v", err)
+	}
+	if td.MeetingLocation == nil || td.MeetingLocation.Address == nil || *td.MeetingLocation.Address != "New" {
+		t.Fatalf("location=%+v", td.MeetingLocation)
+	}
+	if td.MeetingLocation.Label != "Meet" {
+		t.Fatalf("label=%q want=%q", td.MeetingLocation.Label, "Meet")
+	}
+	if td.MeetingLocation.Latitude != nil || td.MeetingLocation.Longitude != nil {
+		t.Fatalf("expected coordinates cleared: %+v", td.MeetingLocation)
+	}
+	if len(td.Artifacts) != 2 || td.Artifacts[0].ArtifactID != "a2" || td.Artifacts[1].ArtifactID != "a1" {
+		t.Fatalf("artifacts=%v", td.Artifacts)
+	}
+
+	// Unknown artifact ID should return 422.
+	_, err = svc.UpdateTrip(ctx, "m1", "tp", trips.UpdateTripInput{
+		ArtifactIDs: trips.Some([]string{"nope"}),
+	})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	ae := (*trips.Error)(nil)
+	if !errors.As(err, &ae) || ae.Status != 422 {
+		t.Fatalf("err=%v", err)
+	}
+
+	// Invalid date range should return 422.
+	start := time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	_, err = svc.UpdateTrip(ctx, "m1", "tp", trips.UpdateTripInput{
+		StartDate: trips.Some(start),
+		EndDate:   trips.Some(end),
+	})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !errors.As(err, &ae) || ae.Status != 422 {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func containsAll(have []string, want []string) bool {
+	set := make(map[string]struct{}, len(have))
+	for _, v := range have {
+		set[v] = struct{}{}
+	}
+	for _, w := range want {
+		if _, ok := set[w]; !ok {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/app/trips/types_test.go
+++ b/internal/app/trips/types_test.go
@@ -1,0 +1,52 @@
+package trips_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Overland-East-Bay/trip-planner-api/internal/app/trips"
+)
+
+func TestOptional_TriStateSemantics(t *testing.T) {
+	t.Parallel()
+
+	u := trips.Unspecified[string]()
+	if u.IsSpecified() {
+		t.Fatalf("Unspecified should not be specified")
+	}
+	if u.IsNull() {
+		t.Fatalf("Unspecified should not be null")
+	}
+	if u.Value() != "" {
+		t.Fatalf("Unspecified Value should be zero value")
+	}
+
+	n := trips.Null[string]()
+	if !n.IsSpecified() {
+		t.Fatalf("Null should be specified")
+	}
+	if !n.IsNull() {
+		t.Fatalf("Null should be null")
+	}
+
+	s := trips.Some("x")
+	if !s.IsSpecified() {
+		t.Fatalf("Some should be specified")
+	}
+	if s.IsNull() {
+		t.Fatalf("Some should not be null")
+	}
+	if s.Value() != "x" {
+		t.Fatalf("Value=%q want=%q", s.Value(), "x")
+	}
+}
+
+func TestOptional_TimeValue(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Unix(123, 0).UTC()
+	o := trips.Some(ts)
+	if !o.IsSpecified() || o.IsNull() || !o.Value().Equal(ts) {
+		t.Fatalf("o=%+v", o)
+	}
+}

--- a/internal/domain/normalize_test.go
+++ b/internal/domain/normalize_test.go
@@ -1,0 +1,29 @@
+package domain
+
+import "testing"
+
+func TestNormalizeHumanName(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"Alice", "Alice"},
+		{"  Alice  ", "Alice"},
+		{"Alice   Smith", "Alice Smith"},
+		{"\tAlice\tSmith\n", "Alice Smith"},
+		{"", ""},
+		{"   \n\t  ", ""},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.in, func(t *testing.T) {
+			t.Parallel()
+			if got := NormalizeHumanName(tc.in); got != tc.want {
+				t.Fatalf("NormalizeHumanName(%q)=%q want=%q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/platform/auth/jwtverifier/extra_test.go
+++ b/internal/platform/auth/jwtverifier/extra_test.go
@@ -1,0 +1,202 @@
+package jwtverifier
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Overland-East-Bay/trip-planner-api/internal/platform/auth/jwks_testutil"
+	"github.com/Overland-East-Bay/trip-planner-api/internal/platform/config"
+)
+
+type fixedClock struct{ now time.Time }
+
+func (c fixedClock) Now() time.Time { return c.now }
+
+func mintRS256JWTWithClaims(t *testing.T, kp jwks_testutil.Keypair, header map[string]any, claims map[string]any) string {
+	t.Helper()
+
+	hb, err := json.Marshal(header)
+	if err != nil {
+		t.Fatalf("marshal header: %v", err)
+	}
+	cb, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshal claims: %v", err)
+	}
+	enc := base64.RawURLEncoding
+	signingInput := enc.EncodeToString(hb) + "." + enc.EncodeToString(cb)
+	sum := sha256.Sum256([]byte(signingInput))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, kp.Private, crypto.SHA256, sum[:])
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	return signingInput + "." + enc.EncodeToString(sig)
+}
+
+func TestVerifier_Verify_AudienceArrayAndNbf(t *testing.T) {
+	t.Parallel()
+
+	jwksSrv, setKeys := jwks_testutil.NewRotatingJWKSServer()
+	defer jwksSrv.Close()
+
+	kp, _ := jwks_testutil.GenerateRSAKeypair("kid-1")
+	setKeys([]jwks_testutil.Keypair{kp})
+
+	clk := fixedClock{now: time.Unix(1700000000, 0)}
+	cfg := config.JWTConfig{
+		Issuer:                 "test-iss",
+		Audience:               "test-aud",
+		JWKSURL:                jwksSrv.URL,
+		ClockSkew:              0,
+		JWKSRefreshInterval:    10 * time.Minute,
+		JWKSMinRefreshInterval: 0,
+		HTTPTimeout:            2 * time.Second,
+	}
+	v := NewWithOptions(cfg, nil, clk)
+
+	// aud as array should be accepted when it contains expected.
+	jwtOK, err := jwks_testutil.MintRS256JWT(kp, cfg.Issuer, []string{"other", cfg.Audience}, "member-123", clk.Now(), 5*time.Minute, nil)
+	if err != nil {
+		t.Fatalf("MintRS256JWT: %v", err)
+	}
+	if sub, err := v.Verify(context.Background(), jwtOK); err != nil || sub != "member-123" {
+		t.Fatalf("Verify(sub=%q, err=%v)", sub, err)
+	}
+
+	// nbf in the future should be rejected.
+	nbfDelta := 1 * time.Minute
+	jwtNBF, err := jwks_testutil.MintRS256JWT(kp, cfg.Issuer, cfg.Audience, "member-123", clk.Now(), 5*time.Minute, &nbfDelta)
+	if err != nil {
+		t.Fatalf("MintRS256JWT(nbf): %v", err)
+	}
+	if _, err := v.Verify(context.Background(), jwtNBF); err == nil {
+		t.Fatalf("expected nbf token to be rejected")
+	}
+}
+
+func TestVerifier_Verify_MissingExpOrSubRejected(t *testing.T) {
+	t.Parallel()
+
+	jwksSrv, setKeys := jwks_testutil.NewRotatingJWKSServer()
+	defer jwksSrv.Close()
+
+	kp, _ := jwks_testutil.GenerateRSAKeypair("kid-1")
+	setKeys([]jwks_testutil.Keypair{kp})
+
+	clk := fixedClock{now: time.Unix(1700000000, 0)}
+	cfg := config.JWTConfig{
+		Issuer:                 "test-iss",
+		Audience:               "test-aud",
+		JWKSURL:                jwksSrv.URL,
+		ClockSkew:              0,
+		JWKSRefreshInterval:    10 * time.Minute,
+		JWKSMinRefreshInterval: 0,
+		HTTPTimeout:            2 * time.Second,
+	}
+	v := NewWithOptions(cfg, nil, clk)
+
+	header := map[string]any{"alg": "RS256", "typ": "JWT", "kid": kp.Kid}
+
+	// Missing exp.
+	jwtNoExp := mintRS256JWTWithClaims(t, kp, header, map[string]any{
+		"iss": cfg.Issuer,
+		"aud": cfg.Audience,
+		"sub": "member-123",
+	})
+	if _, err := v.Verify(context.Background(), jwtNoExp); err == nil {
+		t.Fatalf("expected missing-exp token to be rejected")
+	}
+
+	// Missing sub.
+	jwtNoSub, err := jwks_testutil.MintRS256JWT(kp, cfg.Issuer, cfg.Audience, "", clk.Now(), 5*time.Minute, nil)
+	if err != nil {
+		t.Fatalf("MintRS256JWT: %v", err)
+	}
+	if _, err := v.Verify(context.Background(), jwtNoSub); err == nil {
+		t.Fatalf("expected missing-sub token to be rejected")
+	}
+}
+
+func TestVerifier_Verify_InvalidAlgOrKidShortCircuits(t *testing.T) {
+	t.Parallel()
+
+	// alg != RS256.
+	h := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"HS256","kid":"kid-1","typ":"JWT"}`))
+	c := base64.RawURLEncoding.EncodeToString([]byte(`{"iss":"x","aud":"y","sub":"z","exp":1700000001}`))
+	s := base64.RawURLEncoding.EncodeToString([]byte("sig"))
+	if _, err := New(config.JWTConfig{}).Verify(context.Background(), h+"."+c+"."+s); err == nil {
+		t.Fatalf("expected error")
+	}
+
+	// kid empty.
+	h2 := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","kid":"","typ":"JWT"}`))
+	if _, err := New(config.JWTConfig{}).Verify(context.Background(), h2+"."+c+"."+s); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestVerifier_Verify_JWKSFetchErrorsRejectToken(t *testing.T) {
+	t.Parallel()
+
+	kp, _ := jwks_testutil.GenerateRSAKeypair("kid-1")
+	clk := fixedClock{now: time.Unix(1700000000, 0)}
+
+	jwt, err := jwks_testutil.MintRS256JWT(kp, "test-iss", "test-aud", "member-123", clk.Now(), 5*time.Minute, nil)
+	if err != nil {
+		t.Fatalf("MintRS256JWT: %v", err)
+	}
+
+	t.Run("non-2xx", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("nope"))
+		}))
+		defer srv.Close()
+
+		cfg := config.JWTConfig{Issuer: "test-iss", Audience: "test-aud", JWKSURL: srv.URL, HTTPTimeout: 2 * time.Second}
+		v := NewWithOptions(cfg, nil, clk)
+		if _, err := v.Verify(context.Background(), jwt); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+
+	t.Run("invalid-json", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{not-json"))
+		}))
+		defer srv.Close()
+
+		cfg := config.JWTConfig{Issuer: "test-iss", Audience: "test-aud", JWKSURL: srv.URL, HTTPTimeout: 2 * time.Second}
+		v := NewWithOptions(cfg, nil, clk)
+		if _, err := v.Verify(context.Background(), jwt); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+
+	t.Run("no-keys", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"keys":[]}`))
+		}))
+		defer srv.Close()
+
+		cfg := config.JWTConfig{Issuer: "test-iss", Audience: "test-aud", JWKSURL: srv.URL, HTTPTimeout: 2 * time.Second}
+		v := NewWithOptions(cfg, nil, clk)
+		if _, err := v.Verify(context.Background(), jwt); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+}

--- a/internal/platform/auth/jwtverifier/verifier_test.go
+++ b/internal/platform/auth/jwtverifier/verifier_test.go
@@ -192,3 +192,41 @@ func TestVerifier_Verify_JWKSRotation_OldKidRejected_NewKidAccepted(t *testing.T
 		t.Fatalf("sub mismatch: got %q", sub)
 	}
 }
+
+func TestVerifier_New_UsesDefaultClockAndHTTPClient(t *testing.T) {
+	t.Parallel()
+
+	jwksSrv, setKeys := jwks_testutil.NewRotatingJWKSServer()
+	defer jwksSrv.Close()
+
+	kp, err := jwks_testutil.GenerateRSAKeypair("kid-1")
+	if err != nil {
+		t.Fatalf("GenerateRSAKeypair: %v", err)
+	}
+	setKeys([]jwks_testutil.Keypair{kp})
+
+	cfg := config.JWTConfig{
+		Issuer:                 "test-iss",
+		Audience:               "test-aud",
+		JWKSURL:                jwksSrv.URL,
+		ClockSkew:              0,
+		JWKSRefreshInterval:    10 * time.Minute,
+		JWKSMinRefreshInterval: 0,
+		HTTPTimeout:            2 * time.Second,
+	}
+	v := jwtverifier.New(cfg)
+
+	now := time.Now()
+	jwt, err := jwks_testutil.MintRS256JWT(kp, cfg.Issuer, cfg.Audience, "member-123", now, 5*time.Minute, nil)
+	if err != nil {
+		t.Fatalf("MintRS256JWT: %v", err)
+	}
+
+	sub, err := v.Verify(context.Background(), jwt)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if sub != "member-123" {
+		t.Fatalf("sub mismatch: got %q", sub)
+	}
+}

--- a/internal/platform/clock/system_clock_test.go
+++ b/internal/platform/clock/system_clock_test.go
@@ -1,0 +1,26 @@
+package clock
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSystemClock_Now_IsUTCAndWithinWallClockBounds(t *testing.T) {
+	t.Parallel()
+
+	c := NewSystemClock()
+
+	before := time.Now().UTC()
+	got := c.Now()
+	after := time.Now().UTC()
+
+	if got.IsZero() {
+		t.Fatalf("Now returned zero time")
+	}
+	if got.Location() != time.UTC {
+		t.Fatalf("location=%v want=UTC", got.Location())
+	}
+	if got.Before(before) || got.After(after) {
+		t.Fatalf("got=%s not within [%s, %s]", got, before, after)
+	}
+}

--- a/internal/platform/config/jwt_test.go
+++ b/internal/platform/config/jwt_test.go
@@ -1,0 +1,73 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLoadJWTConfigFromEnv_MissingRequiredVars(t *testing.T) {
+	// Ensure required vars are missing.
+	t.Setenv("JWT_ISSUER", "")
+	t.Setenv("JWT_AUDIENCE", "")
+	t.Setenv("JWT_JWKS_URL", "")
+
+	if _, err := LoadJWTConfigFromEnv(); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestLoadJWTConfigFromEnv_Defaults(t *testing.T) {
+	t.Setenv("JWT_ISSUER", "iss")
+	t.Setenv("JWT_AUDIENCE", "aud")
+	t.Setenv("JWT_JWKS_URL", "https://example.com/jwks.json")
+
+	cfg, err := LoadJWTConfigFromEnv()
+	if err != nil {
+		t.Fatalf("LoadJWTConfigFromEnv: %v", err)
+	}
+	if cfg.Issuer != "iss" || cfg.Audience != "aud" || cfg.JWKSURL != "https://example.com/jwks.json" {
+		t.Fatalf("cfg=%+v", cfg)
+	}
+	if cfg.ClockSkew != 30*time.Second {
+		t.Fatalf("ClockSkew=%s want=30s", cfg.ClockSkew)
+	}
+	if cfg.JWKSRefreshInterval != 5*time.Minute {
+		t.Fatalf("JWKSRefreshInterval=%s want=5m", cfg.JWKSRefreshInterval)
+	}
+	if cfg.JWKSMinRefreshInterval != 10*time.Second {
+		t.Fatalf("JWKSMinRefreshInterval=%s want=10s", cfg.JWKSMinRefreshInterval)
+	}
+	if cfg.HTTPTimeout != 5*time.Second {
+		t.Fatalf("HTTPTimeout=%s want=5s", cfg.HTTPTimeout)
+	}
+}
+
+func TestLoadJWTConfigFromEnv_OverridesAndValidatesDurations(t *testing.T) {
+	t.Setenv("JWT_ISSUER", "iss")
+	t.Setenv("JWT_AUDIENCE", "aud")
+	t.Setenv("JWT_JWKS_URL", "https://example.com/jwks.json")
+	t.Setenv("JWT_CLOCK_SKEW", "1m")
+	t.Setenv("JWT_JWKS_REFRESH_INTERVAL", "2m")
+	t.Setenv("JWT_JWKS_MIN_REFRESH_INTERVAL", "3s")
+
+	cfg, err := LoadJWTConfigFromEnv()
+	if err != nil {
+		t.Fatalf("LoadJWTConfigFromEnv: %v", err)
+	}
+	if cfg.ClockSkew != time.Minute {
+		t.Fatalf("ClockSkew=%s want=1m", cfg.ClockSkew)
+	}
+	if cfg.JWKSRefreshInterval != 2*time.Minute {
+		t.Fatalf("JWKSRefreshInterval=%s want=2m", cfg.JWKSRefreshInterval)
+	}
+	if cfg.JWKSMinRefreshInterval != 3*time.Second {
+		t.Fatalf("JWKSMinRefreshInterval=%s want=3s", cfg.JWKSMinRefreshInterval)
+	}
+
+	t.Run("invalid clock skew", func(t *testing.T) {
+		t.Setenv("JWT_CLOCK_SKEW", "nope")
+		if _, err := LoadJWTConfigFromEnv(); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Add deployment plan + incremental implementation.
- Document deployment/infrastructure guardrails in Constitution.
- Add Terraform bootstrap for tfstate + GitHub OIDC deploy roles.
- Add Terraform module + env roots for ECS Fargate, ALB, and RDS.
- Add GitHub Actions deploy workflows and AWS deployment docs.
- Add ECS migrations task (Dockerfile.migrate) and runbook.
- Add Tilt inner loop with local Postgres + migrations job.
- Add LocalStack rehearsal Terraform root + docs and Make targets.

## Baseline
- Ran baseline test suite before changes: `make ci` (exit 0; last line: `?    github.com/Overland-East-Bay/trip-planner-api/internal/ports/out/triprepo [no test files]`)

## How to verify
- `terraform fmt -check -recursive infra/aws`
- `cd infra/aws/modules/trip-planner-api && terraform init -backend=false && terraform validate`
- `cd infra/aws/envs/staging && terraform init -backend=false && terraform validate`
- `cd infra/aws/envs/prod && terraform init -backend=false && terraform validate`
- `cd infra/local && terraform init -backend=false && terraform validate`
- `tilt up` and follow `docs/tilt.md` for the inner loop
- LocalStack rehearsal: follow `docs/terraform-localstack.md`
- Review `docs/aws-deployment.md` for migration runbook
- AWS staging: smoke tests after deploy (to be added)

## Notes / required config
- GitHub Environments vars/secrets (names only): `AWS_REGION`, `AWS_ROLE_ARN`, `TF_STATE_BUCKET`, `TF_STATE_LOCK_TABLE`, `PROJECT_NAME`, `JWT_ISSUER`, `JWT_AUDIENCE`, `JWT_JWKS_URL`
- Optional vars: `DOMAIN_NAME`, `CERTIFICATE_ARN`, `CREATE_ACM_CERTIFICATE`, `PUBLIC_BASE_URL`
- LocalStack: requires `LOCALSTACK_AUTH_TOKEN` and `docker compose --profile localstack`